### PR TITLE
fix: Add string trim on fields containing evaluable data

### DIFF
--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceToMockResourceEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceToMockResourceEntity.java
@@ -1,16 +1,18 @@
 package it.gov.pagopa.mocker.config.mapper;
 
 import it.gov.pagopa.mocker.config.entity.*;
-import it.gov.pagopa.mocker.config.util.Utility;
 import it.gov.pagopa.mocker.config.model.mockresource.MockCondition;
 import it.gov.pagopa.mocker.config.model.mockresource.MockResource;
 import it.gov.pagopa.mocker.config.model.mockresource.MockResponse;
 import it.gov.pagopa.mocker.config.model.mockresource.MockRule;
+import it.gov.pagopa.mocker.config.util.Utility;
 import org.modelmapper.Converter;
 import org.modelmapper.spi.MappingContext;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 
 public class ConvertMockResourceToMockResourceEntity implements Converter<MockResource, MockResourceEntity> {
 
@@ -18,15 +20,18 @@ public class ConvertMockResourceToMockResourceEntity implements Converter<MockRe
     public MockResourceEntity convert(MappingContext<MockResource, MockResourceEntity> mappingContext) {
         MockResource mockResource = mappingContext.getSource();
 
+        String subsystem = mockResource.getSubsystem().trim();
+        String resourceUrl = mockResource.getResourceURL().trim();
+        String soapAction = mockResource.getSoapAction().trim();
         MockResourceEntity mockResourceEntity = MockResourceEntity.builder()
-                .id(Utility.generateResourceId(mockResource.getHttpMethod(), mockResource.getSubsystem(), mockResource.getResourceURL(), mockResource.getSoapAction()))
+                .id(Utility.generateResourceId(mockResource.getHttpMethod(), subsystem, resourceUrl, soapAction))
                 .name(mockResource.getName())
-                .subsystemUrl(mockResource.getSubsystem())
-                .resourceUrl(mockResource.getResourceURL())
-                .action(mockResource.getSoapAction())
+                .subsystemUrl(subsystem)
+                .resourceUrl(resourceUrl)
+                .action(soapAction)
                 .httpMethod(mockResource.getHttpMethod())
                 .isActive(mockResource.getIsActive())
-                .tags(new HashSet<>(mockResource.getTags()))
+                .tags(new HashSet<>(mockResource.getTags().stream().map(String::trim).filter(value -> !value.isBlank()).toList()))
                 .build();
 
         List<MockRuleEntity> ruleEntities = new LinkedList<>();
@@ -51,7 +56,7 @@ public class ConvertMockResourceToMockResourceEntity implements Converter<MockRe
                 .order(mockRule.getOrder())
                 .isActive(mockRule.getIsActive())
                 .response(mockResponseEntity)
-                .tags(new HashSet<>(mockRule.getTags()))
+                .tags(new HashSet<>(mockRule.getTags().stream().map(String::trim).filter(value -> !value.isBlank()).toList()))
                 .build();
     }
 
@@ -65,7 +70,7 @@ public class ConvertMockResourceToMockResourceEntity implements Converter<MockRe
                             .order(mockCondition.getOrder())
                             .fieldPosition(mockCondition.getFieldPosition())
                             .analyzedContentType(mockCondition.getAnalyzedContentType())
-                            .fieldName(mockCondition.getFieldName())
+                            .fieldName(mockCondition.getFieldName().trim())
                             .conditionType(mockCondition.getConditionType())
                             .conditionValue(mockCondition.getConditionValue())
                             .build()
@@ -83,13 +88,13 @@ public class ConvertMockResourceToMockResourceEntity implements Converter<MockRe
                 .headers(mockResponse.getHeaders()
                         .stream()
                         .map(header -> ResponseHeaderEntity.builder()
-                                .header(header.getName())
+                                .header(header.getName().trim())
                                 .value(header.getValue())
                                 .build()
                         )
-                        .collect(Collectors.toList())
+                        .toList()
                 )
-                .parameters(new HashSet<>(mockResponse.getParameters()))
+                .parameters(new HashSet<>(mockResponse.getParameters().stream().map(String::trim).filter(value -> !value.isBlank()).toList()))
                 .build();
     }
 }

--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockRuleToMockRuleEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockRuleToMockRuleEntity.java
@@ -11,8 +11,10 @@ import it.gov.pagopa.mocker.config.util.Utility;
 import org.modelmapper.Converter;
 import org.modelmapper.spi.MappingContext;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 
 public class ConvertMockRuleToMockRuleEntity implements Converter<MockRule, MockRuleEntity> {
 
@@ -35,7 +37,7 @@ public class ConvertMockRuleToMockRuleEntity implements Converter<MockRule, Mock
                 .order(mockRule.getOrder())
                 .isActive(mockRule.getIsActive())
                 .response(mockResponseEntity)
-                .tags(new HashSet<>(mockRule.getTags()))
+                .tags(new HashSet<>(mockRule.getTags().stream().map(String::trim).filter(value -> !value.isBlank()).toList()))
                 .build();
     }
 
@@ -49,7 +51,7 @@ public class ConvertMockRuleToMockRuleEntity implements Converter<MockRule, Mock
                             .order(mockCondition.getOrder())
                             .fieldPosition(mockCondition.getFieldPosition())
                             .analyzedContentType(mockCondition.getAnalyzedContentType())
-                            .fieldName(mockCondition.getFieldName())
+                            .fieldName(mockCondition.getFieldName().trim())
                             .conditionType(mockCondition.getConditionType())
                             .conditionValue(mockCondition.getConditionValue())
                             .build()
@@ -67,13 +69,13 @@ public class ConvertMockRuleToMockRuleEntity implements Converter<MockRule, Mock
                 .headers(mockResponse.getHeaders()
                         .stream()
                         .map(header -> ResponseHeaderEntity.builder()
-                                .header(header.getName())
+                                .header(header.getName().trim())
                                 .value(header.getValue())
                                 .build()
                         )
-                        .collect(Collectors.toList())
+                        .toList()
                 )
-                .parameters(new HashSet<>(mockResponse.getParameters()))
+                .parameters(new HashSet<>(mockResponse.getParameters().stream().map(String::trim).filter(value -> !value.isBlank()).toList()))
                 .build();
     }
 }


### PR DESCRIPTION
This PR contains a little fix made in order to remove empty strings on valuable fields: if some field evaluated by Mocker core system contains an empty string, it can lead to wrong references that cannot be correctly mapped during mocking process. With a simple trim, this process can be avoided. 

#### List of Changes
 - Add trim on fields that can contains values that can be evaluated by Mocker core system

#### Motivation and Context
This fix permits to avoid wrong empty spaces that can lead to wrong field references in Mocker core analysis. 

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.