### PR TITLE
feat: Moved from SOAPAction to multiple special headers handling

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,2866 +1,2636 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "pagoPA Mock Configurator",
-    "description": "A service that permits to configure the mocked responses used by Mocker service",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.2-3-chart-migration-to-v3"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "pagoPA Mocker Configurator",
+    "description" : "A service that permits to configure the mocked responses used by Mocker service",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "1.2.2-3-chart-migration-to-v3"
   },
-  "servers": [
-    {
-      "url": "http://localhost:8080"
-    },
-    {
-      "url": "https://{host}{basePath}",
-      "variables": {
-        "host": {
-          "default": "api.dev.platform.pagopa.it",
-          "enum": [
-            "api.dev.platform.pagopa.it",
-            "api.uat.platform.pagopa.it"
-          ]
-        },
-        "basePath": {
-          "default": "/mock-config/api/v1",
-          "enum": [
-            "/mock-config/auth/api/v1",
-            "/mock-config/api/v1"
-          ]
-        }
+  "servers" : [ {
+    "url" : "http://localhost:8080"
+  }, {
+    "url" : "https://{host}{basePath}",
+    "variables" : {
+      "host" : {
+        "default" : "api.dev.platform.pagopa.it",
+        "enum" : [ "api.dev.platform.pagopa.it", "api.uat.platform.pagopa.it" ]
+      },
+      "basePath" : {
+        "default" : "/mocker-config/api/v1",
+        "enum" : [ "/mocker-config/auth/api/v1", "/mocker-config/api/v1" ]
       }
     }
-  ],
-  "tags": [
-    {
-      "name": "Archetypes",
-      "description": "Everything about Archetypes"
-    },
-    {
-      "name": "Mock Resources",
-      "description": "Everything about Mock Resources"
-    }
-  ],
-  "paths": {
-    "/archetypes": {
-      "get": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Get paginated list of archetypes",
-        "operationId": "getArchetypes",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+  } ],
+  "tags" : [ {
+    "name" : "Archetypes",
+    "description" : "Everything about Archetypes"
+  }, {
+    "name" : "Mock Resources",
+    "description" : "Everything about Mock Resources"
+  } ],
+  "paths" : {
+    "/archetypes" : {
+      "get" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Get paginated list of archetypes",
+        "operationId" : "getArchetypes",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchetypeList"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArchetypeList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create a new archetype",
-        "operationId": "createArchetype",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Archetype"
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create a new archetype",
+        "operationId" : "createArchetype",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Archetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Delete all existing archetypes by criteria",
-        "operationId": "deleteMockResource_1",
-        "parameters": [
-          {
-            "name": "subsystem",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Delete all existing archetypes by criteria",
+        "operationId" : "deleteMockResource_1",
+        "parameters" : [ {
+          "name" : "subsystem",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/import": {
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create multiple archetypes from OpenAPI specification",
-        "operationId": "importArchetypesFromOpenAPI",
-        "parameters": [
-          {
-            "name": "subsystem",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/import" : {
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create multiple archetypes from OpenAPI specification",
+        "operationId" : "importArchetypesFromOpenAPI",
+        "parameters" : [ {
+          "name" : "subsystem",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "description": "JSON file containing the OpenAPI to analyze",
-                    "format": "binary"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "required" : [ "file" ],
+                "type" : "object",
+                "properties" : {
+                  "file" : {
+                    "type" : "string",
+                    "description" : "JSON file containing the OpenAPI to analyze",
+                    "format" : "binary"
                   }
                 }
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchetypeHandlingResult"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArchetypeHandlingResult"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/{archetypeId}": {
-      "get": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Get detail of a single archetype",
-        "operationId": "getArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/{archetypeId}" : {
+      "get" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Get detail of a single archetype",
+        "operationId" : "getArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Update an existing archetype",
-        "operationId": "updateArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Update an existing archetype",
+        "operationId" : "updateArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Archetype"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Archetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/{archetypeId}/generate": {
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create a new mock resource starting from archetype",
-        "operationId": "createMockResourceFromArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/{archetypeId}/generate" : {
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create a new mock resource starting from archetype",
+        "operationId" : "createMockResourceFromArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResourceFromArchetype"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResourceFromArchetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return the application running status",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return the application running status",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources": {
-      "get": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Get paginated list of mock resource",
-        "operationId": "getMockResources",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+    "/resources" : {
+      "get" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Get paginated list of mock resource",
+        "operationId" : "getMockResources",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResourceList"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResourceList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Create a new mock resource",
-        "operationId": "createMockResource",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResource"
+      "post" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Create a new mock resource",
+        "operationId" : "createMockResource",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResource"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}": {
-      "get": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Get detail of a single mock resource",
-        "operationId": "getMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}" : {
+      "get" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Get detail of a single mock resource",
+        "operationId" : "getMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Update an existing mock resource",
-        "operationId": "updateMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Update an existing mock resource",
+        "operationId" : "updateMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResource"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResource"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Delete an existing mock resource",
-        "operationId": "deleteMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Delete an existing mock resource",
+        "operationId" : "deleteMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "204": {
-            "description": "No content",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/general-info": {
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Partially update an existing mock resource, changing only the general info",
-        "operationId": "updateMockResourceGeneralInfo",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/general-info" : {
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Partially update an existing mock resource, changing only the general info",
+        "operationId" : "updateMockResourceGeneralInfo",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResourceGeneralInfo"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResourceGeneralInfo"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/rules": {
-      "post": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Create a new mock rule for certain mock resource",
-        "operationId": "createMockRule",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/rules" : {
+      "post" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Create a new mock rule for certain mock resource",
+        "operationId" : "createMockRule",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockRule"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockRule"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/rules/{ruleId}": {
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Update an existing mock rule for certain mock resource",
-        "operationId": "updateMockRule",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ruleId",
-            "in": "path",
-            "description": "The identifier related to the mock rule",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/rules/{ruleId}" : {
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Update an existing mock rule for certain mock resource",
+        "operationId" : "updateMockRule",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockRule"
+        }, {
+          "name" : "ruleId",
+          "in" : "path",
+          "description" : "The identifier related to the mock rule",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockRule"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "MockCondition": {
-        "required": [
-          "analyzed_content_type",
-          "condition_type",
-          "field_name",
-          "field_position",
-          "order"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock condition.",
-            "example": "6b0b003d-74f4-428e-b950-61f42e02bf07"
+  "components" : {
+    "schemas" : {
+      "MockCondition" : {
+        "required" : [ "analyzed_content_type", "condition_type", "field_name", "field_position", "order" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock condition.",
+            "example" : "6b0b003d-74f4-428e-b950-61f42e02bf07"
           },
-          "order": {
-            "type": "integer",
-            "description": "The cardinal order on which the mock condition will be evaluated by Mocker.",
-            "format": "int32",
-            "example": 1
+          "order" : {
+            "type" : "integer",
+            "description" : "The cardinal order on which the mock condition will be evaluated by Mocker.",
+            "format" : "int32",
+            "example" : 1
           },
-          "field_position": {
-            "type": "string",
-            "description": "The parameter that define where the field/element that will be evaluated by this condition is located in the request.",
-            "example": "BODY",
-            "enum": [
-              "BODY",
-              "HEADER",
-              "URL"
-            ]
+          "field_position" : {
+            "type" : "string",
+            "description" : "The parameter that define where the field/element that will be evaluated by this condition is located in the request.",
+            "example" : "BODY",
+            "enum" : [ "BODY", "HEADER", "URL" ]
           },
-          "analyzed_content_type": {
-            "type": "string",
-            "description": "The parameter that define the type of the source in the request where the field/element that will be evaluated by this condition will be extracted.",
-            "example": "JSON",
-            "enum": [
-              "JSON",
-              "XML",
-              "STRING"
-            ]
+          "analyzed_content_type" : {
+            "type" : "string",
+            "description" : "The parameter that define the type of the source in the request where the field/element that will be evaluated by this condition will be extracted.",
+            "example" : "JSON",
+            "enum" : [ "JSON", "XML", "STRING" ]
           },
-          "field_name": {
-            "type": "string",
-            "description": "The parameter that define the identifier of the field/element that will be evaluated by this condition",
-            "example": "station.id"
+          "field_name" : {
+            "type" : "string",
+            "description" : "The parameter that define the identifier of the field/element that will be evaluated by this condition",
+            "example" : "station.id"
           },
-          "condition_type": {
-            "type": "string",
-            "description": "The parameter that define the type of condition that will be applied on the field/element that will be evaluated.",
-            "example": "EQ",
-            "enum": [
-              "REGEX",
-              "EQ",
-              "NEQ",
-              "LT",
-              "GT",
-              "LE",
-              "GE",
-              "NULL",
-              "ANY"
-            ]
+          "condition_type" : {
+            "type" : "string",
+            "description" : "The parameter that define the type of condition that will be applied on the field/element that will be evaluated.",
+            "example" : "EQ",
+            "enum" : [ "REGEX", "EQ", "NEQ", "LT", "GT", "LE", "GE", "NULL", "ANY" ]
           },
-          "condition_value": {
-            "type": "string",
-            "description": "The parameter that define the value that the field/element must respect following the condition type.",
-            "example": "77777777777_01"
+          "condition_value" : {
+            "type" : "string",
+            "description" : "The parameter that define the value that the field/element must respect following the condition type.",
+            "example" : "77777777777_01"
           }
         },
-        "description": "The condition applied to the mock rule that a request must respect in order to retrieve the mocked response related to the rule."
+        "description" : "The condition applied to the mock rule that a request must respect in order to retrieve the mocked response related to the rule."
       },
-      "MockResource": {
-        "required": [
-          "http_method",
-          "is_active",
-          "name",
-          "rules",
-          "subsystem",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock resource.",
-            "example": "fb5363bcf68f687c9caeddbc221769f6"
+      "MockResource" : {
+        "required" : [ "http_method", "is_active", "name", "rules", "special_headers", "subsystem", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock resource.",
+            "example" : "fb5363bcf68f687c9caeddbc221769f6"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the mock resource is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the mock resource is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
+            "example" : "organizations/77777777777"
           },
-          "soap_action": {
-            "type": "string",
-            "description": "The SOAP action related to the mock resource.",
-            "example": "paVerifyPaymentNotice"
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the mock resource.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the mock resource.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
-          },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
-          },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "special_headers" : {
+            "type" : "array",
+            "description" : "The special headers that can be added to a request in order to better reference a mock resource.",
+            "items" : {
+              "$ref" : "#/components/schemas/SpecialRequestHeader"
             }
           },
-          "rules": {
-            "type": "array",
-            "description": "The list of rules related to the mock resource that will be evaluated by the Mocker.",
-            "items": {
-              "$ref": "#/components/schemas/MockRule"
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
+          },
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
+            }
+          },
+          "rules" : {
+            "type" : "array",
+            "description" : "The list of rules related to the mock resource that will be evaluated by the Mocker.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockRule"
             }
           }
         },
-        "description": "The mock resource, analyzed by Mocker, that permits to generate different responses based by rules and conditions."
+        "description" : "The mock resource, analyzed by Mocker, that permits to generate different responses based by rules and conditions."
       },
-      "MockResponse": {
-        "required": [
-          "headers",
-          "injected_parameters",
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock response",
-            "example": "26e05a1f-9621-4e24-a57d-28694ff30306"
+      "MockResponse" : {
+        "required" : [ "headers", "injected_parameters", "status" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock response",
+            "example" : "26e05a1f-9621-4e24-a57d-28694ff30306"
           },
-          "body": {
-            "type": "string",
-            "description": "The response body in Base64 format related to the mock response.",
-            "example": "eyJtZXNzYWdlIjoiT0shIn0="
+          "body" : {
+            "type" : "string",
+            "description" : "The response body in Base64 format related to the mock response.",
+            "example" : "eyJtZXNzYWdlIjoiT0shIn0="
           },
-          "status": {
-            "type": "integer",
-            "description": "The HTTP response status related to the mock response.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "type" : "integer",
+            "description" : "The HTTP response status related to the mock response.",
+            "format" : "int32",
+            "example" : 200
           },
-          "headers": {
-            "type": "array",
-            "description": "The list of header to be set to mock response.",
-            "items": {
-              "$ref": "#/components/schemas/ResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "description" : "The list of header to be set to mock response.",
+            "items" : {
+              "$ref" : "#/components/schemas/ResponseHeader"
             }
           },
-          "injected_parameters": {
-            "type": "array",
-            "description": "The list of parameters that will be injected from request body to response body by Mocker.",
-            "items": {
-              "type": "string",
-              "description": "The list of parameters that will be injected from request body to response body by Mocker."
+          "injected_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameters that will be injected from request body to response body by Mocker.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameters that will be injected from request body to response body by Mocker."
             }
           }
         },
-        "description": "The mocked response that will be generated by Mocker if the rule condition are all verified."
+        "description" : "The mocked response that will be generated by Mocker if the rule condition are all verified."
       },
-      "MockRule": {
-        "required": [
-          "conditions",
-          "is_active",
-          "name",
-          "order",
-          "response",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock rule",
-            "example": "6c08a21c-6a92-4f6b-a1e1-bf68c4e099c9"
+      "MockRule" : {
+        "required" : [ "conditions", "is_active", "name", "order", "response", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock rule",
+            "example" : "6c08a21c-6a92-4f6b-a1e1-bf68c4e099c9"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock rule, for human readability.",
-            "example": "Main rule"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock rule, for human readability.",
+            "example" : "Main rule"
           },
-          "order": {
-            "type": "integer",
-            "description": "The cardinal order on which the mock role will be evaluated by Mocker.",
-            "format": "int32",
-            "example": 1
+          "order" : {
+            "type" : "integer",
+            "description" : "The cardinal order on which the mock role will be evaluated by Mocker.",
+            "format" : "int32",
+            "example" : 1
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock rule for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock rule for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock rule is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock rule is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock rule is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock rule is related to."
             }
           },
-          "conditions": {
-            "type": "array",
-            "description": "The list of condition related to the mock rule that will be evaluated in AND by the Mocker.",
-            "items": {
-              "$ref": "#/components/schemas/MockCondition"
+          "conditions" : {
+            "type" : "array",
+            "description" : "The list of condition related to the mock rule that will be evaluated in AND by the Mocker.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockCondition"
             }
           },
-          "response": {
-            "$ref": "#/components/schemas/MockResponse"
+          "response" : {
+            "$ref" : "#/components/schemas/MockResponse"
           }
         },
-        "description": "The rule a passed request can follow in order to obtain the defined mocked response."
+        "description" : "The rule a passed request can follow in order to obtain the defined mocked response."
       },
-      "ResponseHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the header to be set to mock response by Mocker.",
-            "example": "Content-Type"
+      "ResponseHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the header to be set to mock response by Mocker.",
+            "example" : "Content-Type"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the header to be set to mock response by Mocker.",
-            "example": "application/json"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the header to be set to mock response by Mocker.",
+            "example" : "application/json"
           }
         },
-        "description": "The header that will be set to a mocked response"
+        "description" : "The header that will be set to a mocked response"
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "SpecialRequestHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the special header to be set to request to retrieve mock response from Mocker.",
+            "example" : "SOAPAction"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the special header to be set to request to retrieve mock response from Mocker.",
+            "example" : "someSoapAction"
+          }
+        },
+        "description" : "The special header that can be added to a request in order to better reference a mock resource."
+      },
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "MockResourceGeneralInfo": {
-        "required": [
-          "is_active",
-          "name",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+      "MockResourceGeneralInfo" : {
+        "required" : [ "is_active", "name", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
             }
           }
         },
-        "description": "The general information about mock resource, used for partial update."
+        "description" : "The general information about mock resource, used for partial update."
       },
-      "Archetype": {
-        "required": [
-          "http_method",
-          "name",
-          "resource_url",
-          "responses",
-          "subsystem",
-          "tags",
-          "url_parameters"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the archetype.",
-            "example": "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
+      "Archetype" : {
+        "required" : [ "http_method", "name", "resource_url", "responses", "subsystem", "tags", "url_parameters" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the archetype.",
+            "example" : "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the archetype, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the archetype, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the archetype is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the archetype is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the archetype will be defined for the subsystem.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the archetype will be defined for the subsystem.",
+            "example" : "organizations/77777777777"
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the archetype.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the archetype.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the archetype is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the archetype is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the archetype is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the archetype is related to."
             }
           },
-          "url_parameters": {
-            "type": "array",
-            "description": "The list of parameter related to the archetype URL that must be set in mock resource creation.",
-            "items": {
-              "type": "string",
-              "description": "The list of parameter related to the archetype URL that must be set in mock resource creation."
+          "url_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameter related to the archetype URL that must be set in mock resource creation.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameter related to the archetype URL that must be set in mock resource creation."
             }
           },
-          "responses": {
-            "type": "array",
-            "description": "The list of responses related to the archetype that can be edited in mock resource creation.",
-            "items": {
-              "$ref": "#/components/schemas/ArchetypeResponse"
+          "responses" : {
+            "type" : "array",
+            "description" : "The list of responses related to the archetype that can be edited in mock resource creation.",
+            "items" : {
+              "$ref" : "#/components/schemas/ArchetypeResponse"
             }
           }
         }
       },
-      "ArchetypeResponse": {
-        "required": [
-          "headers",
-          "injectable_parameters",
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the archetype response.",
-            "example": "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
+      "ArchetypeResponse" : {
+        "required" : [ "headers", "injectable_parameters", "status" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the archetype response.",
+            "example" : "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
           },
-          "body": {
-            "type": "string"
+          "body" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "integer",
-            "format": "int32"
+          "status" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "headers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArchetypeResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ArchetypeResponseHeader"
             }
           },
-          "injectable_parameters": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "injectable_parameters" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           }
         },
-        "description": "The list of responses related to the archetype that can be edited in mock resource creation."
+        "description" : "The list of responses related to the archetype that can be edited in mock resource creation."
       },
-      "ArchetypeResponseHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the header to be set to archetype.",
-            "example": "Content-Type"
+      "ArchetypeResponseHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the header to be set to archetype.",
+            "example" : "Content-Type"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the header to be set to archetype.",
-            "example": "application/json"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the header to be set to archetype.",
+            "example" : "application/json"
           }
         },
-        "description": "The header that will be set to a mocked response generated by the archetype"
+        "description" : "The header that will be set to a mocked response generated by the archetype"
       },
-      "MockResourceFromArchetype": {
-        "type": "object",
-        "properties": {
-          "is_active": {
-            "type": "boolean"
+      "MockResourceFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "is_active" : {
+            "type" : "boolean"
           },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "tags" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           },
-          "url_parameters": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StaticParameterValue"
+          "url_parameters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StaticParameterValue"
             }
           },
-          "rules": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MockRuleFromArchetype"
+          "rules" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MockRuleFromArchetype"
             }
           }
         }
       },
-      "MockResponseFromArchetype": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "integer",
-            "format": "int32"
+      "MockResponseFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "headers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ResponseHeader"
             }
           },
-          "static_values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StaticParameterValue"
+          "static_values" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StaticParameterValue"
             }
           }
         }
       },
-      "MockRuleFromArchetype": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "MockRuleFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "order": {
-            "type": "integer",
-            "format": "int32"
+          "order" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "is_active": {
-            "type": "boolean"
+          "is_active" : {
+            "type" : "boolean"
           },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "tags" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           },
-          "conditions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MockCondition"
+          "conditions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MockCondition"
             }
           },
-          "response": {
-            "$ref": "#/components/schemas/MockResponseFromArchetype"
+          "response" : {
+            "$ref" : "#/components/schemas/MockResponseFromArchetype"
           }
         }
       },
-      "StaticParameterValue": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "StaticParameterValue" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "ArchetypeHandlingResult": {
-        "type": "object",
-        "properties": {
-          "subsystem_url": {
-            "type": "string"
+      "ArchetypeHandlingResult" : {
+        "type" : "object",
+        "properties" : {
+          "subsystem_url" : {
+            "type" : "string"
           },
-          "generated_archetypes": {
-            "type": "integer",
-            "format": "int32"
+          "generated_archetypes" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },
-      "MockResourceList": {
-        "required": [
-          "page_info",
-          "resources"
-        ],
-        "type": "object",
-        "properties": {
-          "resources": {
-            "type": "array",
-            "description": "The list of retrieved mock resources.",
-            "items": {
-              "$ref": "#/components/schemas/MockResourceReduced"
+      "MockResourceList" : {
+        "required" : [ "page_info", "resources" ],
+        "type" : "object",
+        "properties" : {
+          "resources" : {
+            "type" : "array",
+            "description" : "The list of retrieved mock resources.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockResourceReduced"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         },
-        "description": "The paginated list of mock resources."
+        "description" : "The paginated list of mock resources."
       },
-      "MockResourceReduced": {
-        "required": [
-          "http_method",
-          "is_active",
-          "name",
-          "subsystem",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock resource.",
-            "example": "fb5363bcf68f687c9caeddbc221769f6"
+      "MockResourceReduced" : {
+        "required" : [ "http_method", "is_active", "name", "subsystem", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock resource.",
+            "example" : "fb5363bcf68f687c9caeddbc221769f6"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the mock resource is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the mock resource is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
+            "example" : "organizations/77777777777"
           },
-          "soap_action": {
-            "type": "string",
-            "description": "The SOAP action related to the mock resource.",
-            "example": "paVerifyPaymentNotice"
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the mock resource.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the mock resource.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
+          "special_headers" : {
+            "type" : "array",
+            "description" : "The special headers that can be added to a request in order to better reference a mock resource.",
+            "items" : {
+              "$ref" : "#/components/schemas/SpecialRequestHeader"
+            }
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
             }
           }
         },
-        "description": "The mock resource main info."
+        "description" : "The mock resource main info."
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         },
-        "description": "The information related to the result page."
+        "description" : "The information related to the result page."
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the application."
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the application."
           },
-          "version": {
-            "type": "string",
-            "description": "The version related to the installed application."
+          "version" : {
+            "type" : "string",
+            "description" : "The version related to the installed application."
           },
-          "environment": {
-            "type": "string",
-            "description": "The environment tag on which the application is installed."
+          "environment" : {
+            "type" : "string",
+            "description" : "The environment tag on which the application is installed."
           },
-          "db_connection": {
-            "type": "string",
-            "description": "The status related to the database connection.",
-            "enum": [
-              "up",
-              "down"
-            ]
+          "db_connection" : {
+            "type" : "string",
+            "description" : "The status related to the database connection.",
+            "enum" : [ "up", "down" ]
           }
         }
       },
-      "ArchetypeList": {
-        "required": [
-          "page_info",
-          "resources"
-        ],
-        "type": "object",
-        "properties": {
-          "resources": {
-            "type": "array",
-            "description": "The list of retrieved archetypes.",
-            "items": {
-              "$ref": "#/components/schemas/Archetype"
+      "ArchetypeList" : {
+        "required" : [ "page_info", "resources" ],
+        "type" : "object",
+        "properties" : {
+          "resources" : {
+            "type" : "array",
+            "description" : "The list of retrieved archetypes.",
+            "items" : {
+              "$ref" : "#/components/schemas/Archetype"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         },
-        "description": "The paginated list of archetypes."
+        "description" : "The paginated list of archetypes."
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       },
-      "Authorization": {
-        "type": "http",
-        "description": "JWT token get after Azure Login",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "Authorization" : {
+        "type" : "http",
+        "description" : "JWT token get after Azure Login",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
       }
     }
   }

--- a/src/main/java/it/gov/pagopa/mocker/config/entity/MockResourceEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/entity/MockResourceEntity.java
@@ -4,7 +4,7 @@ import it.gov.pagopa.mocker.config.model.enumeration.HttpMethod;
 import lombok.*;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import javax.persistence.*;
+import javax.persistence.Id;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
@@ -25,9 +25,9 @@ public class MockResourceEntity implements Serializable {
 
     private String resourceUrl;
 
-    private String action;
-
     private HttpMethod httpMethod;
+
+    private List<SpecialRequestHeaderEntity> specialHeaders;
 
     private Boolean isActive;
 

--- a/src/main/java/it/gov/pagopa/mocker/config/entity/SpecialRequestHeaderEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/entity/SpecialRequestHeaderEntity.java
@@ -1,0 +1,19 @@
+package it.gov.pagopa.mocker.config.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class SpecialRequestHeaderEntity implements Serializable {
+
+    private String name;
+
+    private String value;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceEntityToMockResource.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceEntityToMockResource.java
@@ -11,7 +11,6 @@ import org.modelmapper.spi.MappingContext;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ConvertMockResourceEntityToMockResource implements Converter<MockResourceEntity, MockResource> {
 
@@ -29,8 +28,12 @@ public class ConvertMockResourceEntityToMockResource implements Converter<MockRe
                     .body(srcResponse.getBody())
                     .status(srcResponse.getStatus())
                     .parameters(new ArrayList<>(srcResponse.getParameters()))
-                    .headers(srcResponse.getHeaders().stream().map(header -> ResponseHeader.builder().name(header.getHeader()).value(header.getValue()).build()
-                    ).collect(Collectors.toList()))
+                    .headers(srcResponse.getHeaders().stream()
+                            .map(header -> ResponseHeader.builder()
+                                    .name(header.getHeader())
+                                    .value(header.getValue())
+                                    .build())
+                            .toList())
                     .build();
 
             List<MockCondition> conditions = new ArrayList<>();
@@ -67,7 +70,12 @@ public class ConvertMockResourceEntityToMockResource implements Converter<MockRe
                 .name(source.getName())
                 .subsystem(source.getSubsystemUrl())
                 .resourceURL(source.getResourceUrl())
-                .soapAction(source.getAction())
+                .specialHeaders(source.getSpecialHeaders().stream()
+                        .map(header -> SpecialRequestHeader.builder()
+                                .name(header.getName())
+                                .value(header.getValue())
+                                .build())
+                        .toList())
                 .httpMethod(source.getHttpMethod())
                 .isActive(source.getIsActive())
                 .tags(new ArrayList<>(source.getTags()))

--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceEntityToMockResourceReduced.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceEntityToMockResourceReduced.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.mocker.config.mapper;
 
 import it.gov.pagopa.mocker.config.entity.MockResourceEntity;
 import it.gov.pagopa.mocker.config.model.mockresource.MockResourceReduced;
+import it.gov.pagopa.mocker.config.model.mockresource.SpecialRequestHeader;
 import org.modelmapper.Converter;
 import org.modelmapper.spi.MappingContext;
 
@@ -19,7 +20,12 @@ public class ConvertMockResourceEntityToMockResourceReduced implements Converter
                 .name(source.getName())
                 .subsystem(source.getSubsystemUrl())
                 .resourceURL(source.getResourceUrl())
-                .soapAction(source.getAction())
+                .specialHeaders(source.getSpecialHeaders().stream()
+                        .map(header -> SpecialRequestHeader.builder()
+                                .name(header.getName())
+                                .value(header.getValue())
+                                .build())
+                        .toList())
                 .httpMethod(source.getHttpMethod())
                 .isActive(source.getIsActive())
                 .tags(new ArrayList<>(source.getTags()));

--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceFromArchetypeToMockResource.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceFromArchetypeToMockResource.java
@@ -1,28 +1,29 @@
 package it.gov.pagopa.mocker.config.mapper;
 
+import it.gov.pagopa.mocker.config.entity.*;
 import it.gov.pagopa.mocker.config.model.archetype.MockResourceFromArchetype;
 import it.gov.pagopa.mocker.config.model.archetype.MockResponseFromArchetype;
 import it.gov.pagopa.mocker.config.model.archetype.MockRuleFromArchetype;
 import it.gov.pagopa.mocker.config.model.mockresource.MockCondition;
 import it.gov.pagopa.mocker.config.util.Utility;
-import it.gov.pagopa.mocker.config.entity.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class ConvertMockResourceFromArchetypeToMockResource {
 
-    private ConvertMockResourceFromArchetypeToMockResource() {}
+    private ConvertMockResourceFromArchetypeToMockResource() {
+    }
 
     public static MockResourceEntity convert(MockResourceFromArchetype mockResourceFromArchetype, ArchetypeEntity archetypeEntity, String resourceUrl) {
 
         // generating the mock resource
         MockResourceEntity mockResourceEntity = MockResourceEntity.builder()
-                .id(Utility.generateResourceId(archetypeEntity.getHttpMethod(), archetypeEntity.getSubsystemUrl(), resourceUrl, archetypeEntity.getAction()))
+                .id(Utility.generateResourceId(archetypeEntity.getHttpMethod(), archetypeEntity.getSubsystemUrl(), resourceUrl, List.of()))
                 .name(archetypeEntity.getName())
                 .subsystemUrl(archetypeEntity.getSubsystemUrl())
                 .resourceUrl(resourceUrl)
-                .action(archetypeEntity.getAction())
+                .specialHeaders(List.of())
                 .httpMethod(archetypeEntity.getHttpMethod())
                 .isActive(mockResourceFromArchetype.isActive())
                 .rules(new LinkedList<>())

--- a/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockResource.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockResource.java
@@ -46,14 +46,15 @@ public class MockResource implements Serializable {
     @Schema(description = "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.", example = "organizations/77777777777")
     private String resourceURL;
 
-    @JsonProperty("soap_action")
-    @Schema(description = "The SOAP action related to the mock resource.", example = "paVerifyPaymentNotice")
-    private String soapAction;
-
     @JsonProperty("http_method")
     @Schema(description = "The HTTP method related to the mock resource.", example = "GET")
     @NotNull(message = "The HTTP method related to the mock resource cannot be null.")
     private HttpMethod httpMethod;
+
+    @JsonProperty("special_headers")
+    @Schema(description = "The special headers that can be added to a request in order to better reference a mock resource.")
+    @NotNull(message = "The list of special headers to be assigned to the mock resource cannot be null.")
+    private List<SpecialRequestHeader> specialHeaders;
 
     @JsonProperty("is_active")
     @Schema(description = "The status flag that permits to activate or not the mock resource for Mocker evaluation.", example = "true")
@@ -62,7 +63,7 @@ public class MockResource implements Serializable {
 
     @JsonProperty("tags")
     @Schema(description = "The set of tags on which the mock resource is related to.")
-    @NotNull(message = "The list of tags to be assigned the mock resource cannot be null.")
+    @NotNull(message = "The list of tags to be assigned to the mock resource cannot be null.")
     private List<String> tags;
 
     @JsonProperty("rules")

--- a/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockResourceReduced.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockResourceReduced.java
@@ -45,14 +45,14 @@ public class MockResourceReduced implements Serializable {
     @Schema(description = "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.", example = "organizations/77777777777")
     private String resourceURL;
 
-    @JsonProperty("soap_action")
-    @Schema(description = "The SOAP action related to the mock resource.", example = "paVerifyPaymentNotice")
-    private String soapAction;
-
     @JsonProperty("http_method")
     @Schema(description = "The HTTP method related to the mock resource.", example = "GET")
     @NotNull(message = "The HTTP method related to the mock resource cannot be null.")
     private HttpMethod httpMethod;
+
+    @JsonProperty("special_headers")
+    @Schema(description = "The special headers that can be added to a request in order to better reference a mock resource.")
+    private List<SpecialRequestHeader> specialHeaders;
 
     @JsonProperty("is_active")
     @Schema(description = "The status flag that permits to activate or not the mock resource for Mocker evaluation.", example = "true")

--- a/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/SpecialRequestHeader.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/SpecialRequestHeader.java
@@ -1,0 +1,36 @@
+package it.gov.pagopa.mocker.config.model.mockresource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+/**
+ * The model that define the header that will be set to a mocked response
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "The special header that can be added to a request in order to better reference a mock resource.")
+public class SpecialRequestHeader implements Serializable {
+
+    @JsonProperty("name")
+    @Schema(description = "The key of the special header to be set to request to retrieve mock response from Mocker.", example = "SOAPAction")
+    @NotNull(message = "The name of the special header to be assigned to the mock resource cannot be null.")
+    @NotBlank(message = "The name of the special header to be assigned to the mock resource cannot be blank.")
+    private String name;
+
+    @JsonProperty("value")
+    @Schema(description = "The value of the special header to be set to request to retrieve mock response from Mocker.", example = "someSoapAction")
+    @NotNull(message = "The value of the special header to be assigned to the mock resource cannot be null.")
+    private String value;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/util/Utility.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/util/Utility.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.mocker.config.util;
 import it.gov.pagopa.mocker.config.model.PageInfo;
 import it.gov.pagopa.mocker.config.model.enumeration.HttpMethod;
 import it.gov.pagopa.mocker.config.model.mockresource.MockResource;
+import it.gov.pagopa.mocker.config.model.mockresource.SpecialRequestHeader;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 
@@ -16,88 +17,95 @@ import java.util.stream.Collectors;
 @Slf4j
 public class Utility {
 
-  private Utility() {}
-
-  public static <T> PageInfo buildPageInfo(Page<T> page) {
-    return PageInfo.builder()
-        .page(page.getNumber())
-        .limit(page.getSize())
-        .totalPages(page.getTotalPages())
-        .itemsFound(page.getNumberOfElements())
-        .build();
-  }
-
-  public static String deNull(Object value) {
-    return Optional.ofNullable(value).orElse("").toString();
-  }
-
-  public static String generateUUID() {
-    return UUID.randomUUID().toString();
-  }
-
-  public static String generateResourceId(MockResource mockResource) {
-    return generateResourceId(mockResource.getHttpMethod(), mockResource.getSubsystem(), mockResource.getResourceURL(), mockResource.getSoapAction());
-  }
-
-  public static String generateResourceId(HttpMethod httpMethod, String subsystem, String resourceURL, String soapAction) {
-    StringBuilder urlBuilder = new StringBuilder();
-    urlBuilder.append("/").append(subsystem);
-    if (!subsystem.endsWith("/") && (resourceURL == null || !resourceURL.startsWith("/"))) {
-      urlBuilder.append("/");
+    private Utility() {
     }
-    if (resourceURL != null) {
-      urlBuilder.append(resourceURL);
-      if (!resourceURL.endsWith("/")) {
-        urlBuilder.append("/");
-      }
-    }
-    String completeUrl = urlBuilder.toString().replace("//", "/");
-    return generateHash(completeUrl, Optional.ofNullable(soapAction).orElse("").toLowerCase(), httpMethod.name().toLowerCase());
-  }
 
-  public static String generateHash(String... content) {
-    String hashedContent = "";
-    try {
-      StringBuilder builder = new StringBuilder();
-      Iterator<String> it = Arrays.stream(content).iterator();
-      while (it.hasNext()) {
-        String element = it.next();
-        builder.append(element);
-        if (it.hasNext() && !Constants.EMPTY_STRING.equals(element)) {
-          builder.append(Constants.WHITESPACE);
+    public static <T> PageInfo buildPageInfo(Page<T> page) {
+        return PageInfo.builder()
+                .page(page.getNumber())
+                .limit(page.getSize())
+                .totalPages(page.getTotalPages())
+                .itemsFound(page.getNumberOfElements())
+                .build();
+    }
+
+    public static String deNull(Object value) {
+        return Optional.ofNullable(value).orElse("").toString();
+    }
+
+    public static String generateUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    public static String generateResourceId(MockResource mockResource) {
+        return generateResourceId(mockResource.getHttpMethod(), mockResource.getSubsystem(), mockResource.getResourceURL(), mockResource.getSpecialHeaders());
+    }
+
+    public static String generateResourceId(HttpMethod httpMethod, String subsystem, String resourceURL, List<SpecialRequestHeader> specialHeaders) {
+        StringBuilder urlBuilder = new StringBuilder();
+        urlBuilder.append("/").append(subsystem);
+        if (!subsystem.endsWith("/") && (resourceURL == null || !resourceURL.startsWith("/"))) {
+            urlBuilder.append("/");
         }
-      }
-      byte[] requestIdBytes = builder.toString().getBytes(StandardCharsets.UTF_8);
-      MessageDigest md = MessageDigest.getInstance("MD5");
-      byte[] digestByteArray = md.digest(requestIdBytes);
-
-      StringBuilder hashStringBuilder = new StringBuilder();
-      for (byte b : digestByteArray) {
-        if ((0xff & b) < 0x10) {
-          hashStringBuilder.append('0');
+        if (resourceURL != null) {
+            urlBuilder.append(resourceURL);
+            if (!resourceURL.endsWith("/")) {
+                urlBuilder.append("/");
+            }
         }
-        hashStringBuilder.append(Integer.toHexString(0xff & b));
-      }
-      hashedContent = hashStringBuilder.toString();
-    } catch (NoSuchAlgorithmException e) {
-      log.error("Error while generating the hash value from objects. No valid algorithm found as 'MD5'.", e);
+        String completeUrl = urlBuilder.toString().replace("//", "/");
+
+        StringJoiner specialHeadersBuilder = new StringJoiner(";");
+        specialHeaders.stream()
+                .map(header -> header.getName().trim().toLowerCase() + ":" + header.getValue().toLowerCase())
+                .sorted()
+                .forEach(specialHeadersBuilder::add);
+        return generateHash(httpMethod.name().toLowerCase(), completeUrl, specialHeadersBuilder.toString());
     }
-    return hashedContent;
-  }
 
-  public static List<String> extractInjectableParameters(String body) {
-    return Pattern.compile("\\$\\{([a-zA-Z0-9_-]+)\\}")
-            .matcher(body)
-            .results()
-            .map(res -> res.group(1))
-            .collect(Collectors.toList());
-  }
+    public static String generateHash(String... content) {
+        String hashedContent = "";
+        try {
+            StringBuilder builder = new StringBuilder();
+            Iterator<String> it = Arrays.stream(content).iterator();
+            while (it.hasNext()) {
+                String element = it.next();
+                builder.append(element);
+                if (it.hasNext() && !Constants.EMPTY_STRING.equals(element)) {
+                    builder.append(Constants.WHITESPACE);
+                }
+            }
+            byte[] requestIdBytes = builder.toString().getBytes(StandardCharsets.UTF_8);
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] digestByteArray = md.digest(requestIdBytes);
 
-  public static List<String> extractURLParameters(String url) {
-    return Pattern.compile("\\{([a-zA-Z0-9_-]+)\\}")
-            .matcher(url)
-            .results()
-            .map(res -> res.group(1))
-            .collect(Collectors.toList());
-  }
+            StringBuilder hashStringBuilder = new StringBuilder();
+            for (byte b : digestByteArray) {
+                if ((0xff & b) < 0x10) {
+                    hashStringBuilder.append('0');
+                }
+                hashStringBuilder.append(Integer.toHexString(0xff & b));
+            }
+            hashedContent = hashStringBuilder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Error while generating the hash value from objects. No valid algorithm found as 'MD5'.", e);
+        }
+        return hashedContent;
+    }
+
+    public static List<String> extractInjectableParameters(String body) {
+        return Pattern.compile("\\$\\{([a-zA-Z0-9_-]+)\\}")
+                .matcher(body)
+                .results()
+                .map(res -> res.group(1))
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> extractURLParameters(String url) {
+        return Pattern.compile("\\{([a-zA-Z0-9_-]+)\\}")
+                .matcher(url)
+                .results()
+                .map(res -> res.group(1))
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
This PR contains several changes made on header evaluation in request that arrives to Mocker. The new handling permits to handle multiple headers, removing the fixed single-header analysis of SOAPAction.  

#### List of Changes
 - Added logic for handle semi-dynamic special headers
 - Refactored DocumentDB entity, replacing `action` field with `specialHeaders`
 - Refactored REST API model, replacing `action` field with `special_headers`
 - Refactored Hash generation, changing the order of fields implied in hashing

#### Motivation and Context
This change is required in order to handle multiple variable headers instead of single SOAPAction header.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.