### PR TITLE
feat: added optional filters on mock resource search

### DIFF
--- a/.github/workflows/04h_deploy_with_github_runner.yml
+++ b/.github/workflows/04h_deploy_with_github_runner.yml
@@ -107,14 +107,14 @@ jobs:
           subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
 
-      - name: Terraform Apply
-        shell: bash
-        run: |
-          cd ./infra
-          export ARM_CLIENT_ID="${{ secrets.CD_CLIENT_ID }}"
-          export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
-          export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
-          export ARM_USE_OIDC=true
-          export ARM_ACCESS_KEY=$(az storage account keys list --resource-group io-infra-rg --account-name pagopainfraterraform${{inputs.environment}} --query '[0].value' -o tsv)
-          bash ./terraform.sh init ${{ inputs.environment }}
-          bash ./terraform.sh apply ${{ inputs.environment }} -auto-approve
+#      - name: Terraform Apply
+#        shell: bash
+#        run: |
+#          cd ./infra
+#          export ARM_CLIENT_ID="${{ secrets.CD_CLIENT_ID }}"
+#          export ARM_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+#          export ARM_TENANT_ID=$(az account show --query tenantId --output tsv)
+#          export ARM_USE_OIDC=true
+#          export ARM_ACCESS_KEY=$(az storage account keys list --resource-group io-infra-rg --account-name pagopainfraterraform${{inputs.environment}} --query '[0].value' -o tsv)
+#          bash ./terraform.sh init ${{ inputs.environment }}
+#          bash ./terraform.sh apply ${{ inputs.environment }} -auto-approve

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,2891 +1,2654 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "pagoPA Mocker Configurator",
-    "description": "A service that permits to configure the mocked responses used by Mocker service",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.3"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "pagoPA Mocker Configurator",
+    "description" : "A service that permits to configure the mocked responses used by Mocker service",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "1.2.3"
   },
-  "servers": [
-    {
-      "url": "http://localhost:8080"
-    },
-    {
-      "url": "https://{host}{basePath}",
-      "variables": {
-        "host": {
-          "default": "api.dev.platform.pagopa.it",
-          "enum": [
-            "api.dev.platform.pagopa.it",
-            "api.uat.platform.pagopa.it"
-          ]
-        },
-        "basePath": {
-          "default": "/mocker-config/api/v1",
-          "enum": [
-            "/mocker-config/auth/api/v1",
-            "/mocker-config/api/v1"
-          ]
-        }
+  "servers" : [ {
+    "url" : "http://localhost:8080"
+  }, {
+    "url" : "https://{host}{basePath}",
+    "variables" : {
+      "host" : {
+        "default" : "api.dev.platform.pagopa.it",
+        "enum" : [ "api.dev.platform.pagopa.it", "api.uat.platform.pagopa.it" ]
+      },
+      "basePath" : {
+        "default" : "/mocker-config/api/v1",
+        "enum" : [ "/mocker-config/auth/api/v1", "/mocker-config/api/v1" ]
       }
     }
-  ],
-  "tags": [
-    {
-      "name": "Archetypes",
-      "description": "Everything about Archetypes"
-    },
-    {
-      "name": "Mock Resources",
-      "description": "Everything about Mock Resources"
-    }
-  ],
-  "paths": {
-    "/archetypes": {
-      "get": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Get paginated list of archetypes",
-        "operationId": "getArchetypes",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+  } ],
+  "tags" : [ {
+    "name" : "Archetypes",
+    "description" : "Everything about Archetypes"
+  }, {
+    "name" : "Mock Resources",
+    "description" : "Everything about Mock Resources"
+  } ],
+  "paths" : {
+    "/archetypes" : {
+      "get" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Get paginated list of archetypes",
+        "operationId" : "getArchetypes",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchetypeList"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArchetypeList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create a new archetype",
-        "operationId": "createArchetype",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Archetype"
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create a new archetype",
+        "operationId" : "createArchetype",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Archetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Delete all existing archetypes by criteria",
-        "operationId": "deleteMockResource_1",
-        "parameters": [
-          {
-            "name": "subsystem",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Delete all existing archetypes by criteria",
+        "operationId" : "deleteMockResource_1",
+        "parameters" : [ {
+          "name" : "subsystem",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/import": {
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create multiple archetypes from OpenAPI specification",
-        "operationId": "importArchetypesFromOpenAPI",
-        "parameters": [
-          {
-            "name": "subsystem",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/import" : {
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create multiple archetypes from OpenAPI specification",
+        "operationId" : "importArchetypesFromOpenAPI",
+        "parameters" : [ {
+          "name" : "subsystem",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "description": "JSON file containing the OpenAPI to analyze",
-                    "format": "binary"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "required" : [ "file" ],
+                "type" : "object",
+                "properties" : {
+                  "file" : {
+                    "type" : "string",
+                    "description" : "JSON file containing the OpenAPI to analyze",
+                    "format" : "binary"
                   }
                 }
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchetypeHandlingResult"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArchetypeHandlingResult"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/{archetypeId}": {
-      "get": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Get detail of a single archetype",
-        "operationId": "getArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/{archetypeId}" : {
+      "get" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Get detail of a single archetype",
+        "operationId" : "getArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Update an existing archetype",
-        "operationId": "updateArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Update an existing archetype",
+        "operationId" : "updateArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Archetype"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Archetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/{archetypeId}/generate": {
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create a new mock resource starting from archetype",
-        "operationId": "createMockResourceFromArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/{archetypeId}/generate" : {
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create a new mock resource starting from archetype",
+        "operationId" : "createMockResourceFromArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResourceFromArchetype"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResourceFromArchetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return the application running status",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return the application running status",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources": {
-      "get": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Get paginated list of mock resource",
-        "operationId": "getMockResources",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+    "/resources" : {
+      "get" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Get paginated list of mock resource",
+        "operationId" : "getMockResources",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        }, {
+          "name" : "name",
+          "in" : "query",
+          "description" : "The name of the mock resource, used as a search filter.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "0"
+          }
+        }, {
+          "name" : "tag",
+          "in" : "query",
+          "description" : "The tag of the mock resource, used as a search filter.",
+          "required" : false,
+          "schema" : {
+            "type" : "string",
+            "default" : "0"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResourceList"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResourceList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Create a new mock resource",
-        "operationId": "createMockResource",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResource"
+      "post" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Create a new mock resource",
+        "operationId" : "createMockResource",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResource"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}": {
-      "get": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Get detail of a single mock resource",
-        "operationId": "getMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}" : {
+      "get" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Get detail of a single mock resource",
+        "operationId" : "getMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Update an existing mock resource",
-        "operationId": "updateMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Update an existing mock resource",
+        "operationId" : "updateMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResource"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResource"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Delete an existing mock resource",
-        "operationId": "deleteMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Delete an existing mock resource",
+        "operationId" : "deleteMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "204": {
-            "description": "No content",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/general-info": {
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Partially update an existing mock resource, changing only the general info",
-        "operationId": "updateMockResourceGeneralInfo",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/general-info" : {
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Partially update an existing mock resource, changing only the general info",
+        "operationId" : "updateMockResourceGeneralInfo",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResourceGeneralInfo"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResourceGeneralInfo"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/rules": {
-      "post": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Create a new mock rule for certain mock resource",
-        "operationId": "createMockRule",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/rules" : {
+      "post" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Create a new mock rule for certain mock resource",
+        "operationId" : "createMockRule",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockRule"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockRule"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/rules/{ruleId}": {
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Update an existing mock rule for certain mock resource",
-        "operationId": "updateMockRule",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ruleId",
-            "in": "path",
-            "description": "The identifier related to the mock rule",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/rules/{ruleId}" : {
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Update an existing mock rule for certain mock resource",
+        "operationId" : "updateMockRule",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockRule"
+        }, {
+          "name" : "ruleId",
+          "in" : "path",
+          "description" : "The identifier related to the mock rule",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockRule"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "MockCondition": {
-        "required": [
-          "analyzed_content_type",
-          "condition_type",
-          "field_name",
-          "field_position",
-          "order"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock condition.",
-            "example": "6b0b003d-74f4-428e-b950-61f42e02bf07"
+  "components" : {
+    "schemas" : {
+      "MockCondition" : {
+        "required" : [ "analyzed_content_type", "condition_type", "field_name", "field_position", "order" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock condition.",
+            "example" : "6b0b003d-74f4-428e-b950-61f42e02bf07"
           },
-          "order": {
-            "type": "integer",
-            "description": "The cardinal order on which the mock condition will be evaluated by Mocker.",
-            "format": "int32",
-            "example": 1
+          "order" : {
+            "type" : "integer",
+            "description" : "The cardinal order on which the mock condition will be evaluated by Mocker.",
+            "format" : "int32",
+            "example" : 1
           },
-          "field_position": {
-            "type": "string",
-            "description": "The parameter that define where the field/element that will be evaluated by this condition is located in the request.",
-            "example": "BODY",
-            "enum": [
-              "BODY",
-              "HEADER",
-              "URL"
-            ]
+          "field_position" : {
+            "type" : "string",
+            "description" : "The parameter that define where the field/element that will be evaluated by this condition is located in the request.",
+            "example" : "BODY",
+            "enum" : [ "BODY", "HEADER", "URL" ]
           },
-          "analyzed_content_type": {
-            "type": "string",
-            "description": "The parameter that define the type of the source in the request where the field/element that will be evaluated by this condition will be extracted.",
-            "example": "JSON",
-            "enum": [
-              "JSON",
-              "XML",
-              "STRING"
-            ]
+          "analyzed_content_type" : {
+            "type" : "string",
+            "description" : "The parameter that define the type of the source in the request where the field/element that will be evaluated by this condition will be extracted.",
+            "example" : "JSON",
+            "enum" : [ "JSON", "XML", "STRING" ]
           },
-          "field_name": {
-            "type": "string",
-            "description": "The parameter that define the identifier of the field/element that will be evaluated by this condition",
-            "example": "station.id"
+          "field_name" : {
+            "type" : "string",
+            "description" : "The parameter that define the identifier of the field/element that will be evaluated by this condition",
+            "example" : "station.id"
           },
-          "condition_type": {
-            "type": "string",
-            "description": "The parameter that define the type of condition that will be applied on the field/element that will be evaluated.",
-            "example": "EQ",
-            "enum": [
-              "REGEX",
-              "EQ",
-              "NEQ",
-              "LT",
-              "GT",
-              "LE",
-              "GE",
-              "NULL",
-              "ANY"
-            ]
+          "condition_type" : {
+            "type" : "string",
+            "description" : "The parameter that define the type of condition that will be applied on the field/element that will be evaluated.",
+            "example" : "EQ",
+            "enum" : [ "REGEX", "EQ", "NEQ", "LT", "GT", "LE", "GE", "NULL", "ANY" ]
           },
-          "condition_value": {
-            "type": "string",
-            "description": "The parameter that define the value that the field/element must respect following the condition type.",
-            "example": "77777777777_01"
+          "condition_value" : {
+            "type" : "string",
+            "description" : "The parameter that define the value that the field/element must respect following the condition type.",
+            "example" : "77777777777_01"
           }
         },
-        "description": "The condition applied to the mock rule that a request must respect in order to retrieve the mocked response related to the rule."
+        "description" : "The condition applied to the mock rule that a request must respect in order to retrieve the mocked response related to the rule."
       },
-      "MockResource": {
-        "required": [
-          "http_method",
-          "is_active",
-          "name",
-          "rules",
-          "special_headers",
-          "subsystem",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock resource.",
-            "example": "fb5363bcf68f687c9caeddbc221769f6"
+      "MockResource" : {
+        "required" : [ "http_method", "is_active", "name", "rules", "special_headers", "subsystem", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock resource.",
+            "example" : "fb5363bcf68f687c9caeddbc221769f6"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the mock resource is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the mock resource is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
+            "example" : "organizations/77777777777"
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the mock resource.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the mock resource.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "special_headers": {
-            "type": "array",
-            "description": "The special headers that can be added to a request in order to better reference a mock resource.",
-            "items": {
-              "$ref": "#/components/schemas/SpecialRequestHeader"
+          "special_headers" : {
+            "type" : "array",
+            "description" : "The special headers that can be added to a request in order to better reference a mock resource.",
+            "items" : {
+              "$ref" : "#/components/schemas/SpecialRequestHeader"
             }
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
             }
           },
-          "rules": {
-            "type": "array",
-            "description": "The list of rules related to the mock resource that will be evaluated by the Mocker.",
-            "items": {
-              "$ref": "#/components/schemas/MockRule"
+          "rules" : {
+            "type" : "array",
+            "description" : "The list of rules related to the mock resource that will be evaluated by the Mocker.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockRule"
             }
           }
         },
-        "description": "The mock resource, analyzed by Mocker, that permits to generate different responses based by rules and conditions."
+        "description" : "The mock resource, analyzed by Mocker, that permits to generate different responses based by rules and conditions."
       },
-      "MockResponse": {
-        "required": [
-          "headers",
-          "injected_parameters",
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock response",
-            "example": "26e05a1f-9621-4e24-a57d-28694ff30306"
+      "MockResponse" : {
+        "required" : [ "headers", "injected_parameters", "status" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock response",
+            "example" : "26e05a1f-9621-4e24-a57d-28694ff30306"
           },
-          "body": {
-            "type": "string",
-            "description": "The response body in Base64 format related to the mock response.",
-            "example": "eyJtZXNzYWdlIjoiT0shIn0="
+          "body" : {
+            "type" : "string",
+            "description" : "The response body in Base64 format related to the mock response.",
+            "example" : "eyJtZXNzYWdlIjoiT0shIn0="
           },
-          "status": {
-            "type": "integer",
-            "description": "The HTTP response status related to the mock response.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "type" : "integer",
+            "description" : "The HTTP response status related to the mock response.",
+            "format" : "int32",
+            "example" : 200
           },
-          "headers": {
-            "type": "array",
-            "description": "The list of header to be set to mock response.",
-            "items": {
-              "$ref": "#/components/schemas/ResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "description" : "The list of header to be set to mock response.",
+            "items" : {
+              "$ref" : "#/components/schemas/ResponseHeader"
             }
           },
-          "injected_parameters": {
-            "type": "array",
-            "description": "The list of parameters that will be injected from request body to response body by Mocker.",
-            "items": {
-              "type": "string",
-              "description": "The list of parameters that will be injected from request body to response body by Mocker."
+          "injected_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameters that will be injected from request body to response body by Mocker.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameters that will be injected from request body to response body by Mocker."
             }
           }
         },
-        "description": "The mocked response that will be generated by Mocker if the rule condition are all verified."
+        "description" : "The mocked response that will be generated by Mocker if the rule condition are all verified."
       },
-      "MockRule": {
-        "required": [
-          "conditions",
-          "is_active",
-          "name",
-          "order",
-          "response",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock rule",
-            "example": "6c08a21c-6a92-4f6b-a1e1-bf68c4e099c9"
+      "MockRule" : {
+        "required" : [ "conditions", "is_active", "name", "order", "response", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock rule",
+            "example" : "6c08a21c-6a92-4f6b-a1e1-bf68c4e099c9"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock rule, for human readability.",
-            "example": "Main rule"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock rule, for human readability.",
+            "example" : "Main rule"
           },
-          "order": {
-            "type": "integer",
-            "description": "The cardinal order on which the mock role will be evaluated by Mocker.",
-            "format": "int32",
-            "example": 1
+          "order" : {
+            "type" : "integer",
+            "description" : "The cardinal order on which the mock role will be evaluated by Mocker.",
+            "format" : "int32",
+            "example" : 1
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock rule for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock rule for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock rule is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock rule is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock rule is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock rule is related to."
             }
           },
-          "conditions": {
-            "type": "array",
-            "description": "The list of condition related to the mock rule that will be evaluated in AND by the Mocker.",
-            "items": {
-              "$ref": "#/components/schemas/MockCondition"
+          "conditions" : {
+            "type" : "array",
+            "description" : "The list of condition related to the mock rule that will be evaluated in AND by the Mocker.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockCondition"
             }
           },
-          "response": {
-            "$ref": "#/components/schemas/MockResponse"
+          "response" : {
+            "$ref" : "#/components/schemas/MockResponse"
           }
         },
-        "description": "The rule a passed request can follow in order to obtain the defined mocked response."
+        "description" : "The rule a passed request can follow in order to obtain the defined mocked response."
       },
-      "ResponseHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the header to be set to mock response by Mocker.",
-            "example": "Content-Type"
+      "ResponseHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the header to be set to mock response by Mocker.",
+            "example" : "Content-Type"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the header to be set to mock response by Mocker.",
-            "example": "application/json"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the header to be set to mock response by Mocker.",
+            "example" : "application/json"
           }
         },
-        "description": "The header that will be set to a mocked response"
+        "description" : "The header that will be set to a mocked response"
       },
-      "SpecialRequestHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the special header to be set to request to retrieve mock response from Mocker.",
-            "example": "SOAPAction"
+      "SpecialRequestHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the special header to be set to request to retrieve mock response from Mocker.",
+            "example" : "SOAPAction"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the special header to be set to request to retrieve mock response from Mocker.",
-            "example": "someSoapAction"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the special header to be set to request to retrieve mock response from Mocker.",
+            "example" : "someSoapAction"
           }
         },
-        "description": "The special header that can be added to a request in order to better reference a mock resource."
+        "description" : "The special header that can be added to a request in order to better reference a mock resource."
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "MockResourceGeneralInfo": {
-        "required": [
-          "is_active",
-          "name",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+      "MockResourceGeneralInfo" : {
+        "required" : [ "is_active", "name", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
             }
           }
         },
-        "description": "The general information about mock resource, used for partial update."
+        "description" : "The general information about mock resource, used for partial update."
       },
-      "Archetype": {
-        "required": [
-          "http_method",
-          "name",
-          "resource_url",
-          "responses",
-          "subsystem",
-          "tags",
-          "url_parameters"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the archetype.",
-            "example": "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
+      "Archetype" : {
+        "required" : [ "http_method", "name", "resource_url", "responses", "subsystem", "tags", "url_parameters" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the archetype.",
+            "example" : "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the archetype, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the archetype, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the archetype is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the archetype is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the archetype will be defined for the subsystem.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the archetype will be defined for the subsystem.",
+            "example" : "organizations/77777777777"
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the archetype.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the archetype.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the archetype is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the archetype is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the archetype is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the archetype is related to."
             }
           },
-          "url_parameters": {
-            "type": "array",
-            "description": "The list of parameter related to the archetype URL that must be set in mock resource creation.",
-            "items": {
-              "type": "string",
-              "description": "The list of parameter related to the archetype URL that must be set in mock resource creation."
+          "url_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameter related to the archetype URL that must be set in mock resource creation.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameter related to the archetype URL that must be set in mock resource creation."
             }
           },
-          "responses": {
-            "type": "array",
-            "description": "The list of responses related to the archetype that can be edited in mock resource creation.",
-            "items": {
-              "$ref": "#/components/schemas/ArchetypeResponse"
+          "responses" : {
+            "type" : "array",
+            "description" : "The list of responses related to the archetype that can be edited in mock resource creation.",
+            "items" : {
+              "$ref" : "#/components/schemas/ArchetypeResponse"
             }
           }
         }
       },
-      "ArchetypeResponse": {
-        "required": [
-          "headers",
-          "injectable_parameters",
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the archetype response.",
-            "example": "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
+      "ArchetypeResponse" : {
+        "required" : [ "headers", "injectable_parameters", "status" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the archetype response.",
+            "example" : "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
           },
-          "body": {
-            "type": "string"
+          "body" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "integer",
-            "format": "int32"
+          "status" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "headers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArchetypeResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ArchetypeResponseHeader"
             }
           },
-          "injectable_parameters": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "injectable_parameters" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           }
         },
-        "description": "The list of responses related to the archetype that can be edited in mock resource creation."
+        "description" : "The list of responses related to the archetype that can be edited in mock resource creation."
       },
-      "ArchetypeResponseHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the header to be set to archetype.",
-            "example": "Content-Type"
+      "ArchetypeResponseHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the header to be set to archetype.",
+            "example" : "Content-Type"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the header to be set to archetype.",
-            "example": "application/json"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the header to be set to archetype.",
+            "example" : "application/json"
           }
         },
-        "description": "The header that will be set to a mocked response generated by the archetype"
+        "description" : "The header that will be set to a mocked response generated by the archetype"
       },
-      "MockResourceFromArchetype": {
-        "type": "object",
-        "properties": {
-          "is_active": {
-            "type": "boolean"
+      "MockResourceFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "is_active" : {
+            "type" : "boolean"
           },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "tags" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           },
-          "url_parameters": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StaticParameterValue"
+          "url_parameters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StaticParameterValue"
             }
           },
-          "rules": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MockRuleFromArchetype"
+          "rules" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MockRuleFromArchetype"
             }
           }
         }
       },
-      "MockResponseFromArchetype": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "integer",
-            "format": "int32"
+      "MockResponseFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "headers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ResponseHeader"
             }
           },
-          "static_values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StaticParameterValue"
+          "static_values" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StaticParameterValue"
             }
           }
         }
       },
-      "MockRuleFromArchetype": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "MockRuleFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "order": {
-            "type": "integer",
-            "format": "int32"
+          "order" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "is_active": {
-            "type": "boolean"
+          "is_active" : {
+            "type" : "boolean"
           },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "tags" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           },
-          "conditions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MockCondition"
+          "conditions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MockCondition"
             }
           },
-          "response": {
-            "$ref": "#/components/schemas/MockResponseFromArchetype"
+          "response" : {
+            "$ref" : "#/components/schemas/MockResponseFromArchetype"
           }
         }
       },
-      "StaticParameterValue": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "StaticParameterValue" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "ArchetypeHandlingResult": {
-        "type": "object",
-        "properties": {
-          "subsystem_url": {
-            "type": "string"
+      "ArchetypeHandlingResult" : {
+        "type" : "object",
+        "properties" : {
+          "subsystem_url" : {
+            "type" : "string"
           },
-          "generated_archetypes": {
-            "type": "integer",
-            "format": "int32"
+          "generated_archetypes" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },
-      "MockResourceList": {
-        "required": [
-          "page_info",
-          "resources"
-        ],
-        "type": "object",
-        "properties": {
-          "resources": {
-            "type": "array",
-            "description": "The list of retrieved mock resources.",
-            "items": {
-              "$ref": "#/components/schemas/MockResourceReduced"
+      "MockResourceList" : {
+        "required" : [ "page_info", "resources" ],
+        "type" : "object",
+        "properties" : {
+          "resources" : {
+            "type" : "array",
+            "description" : "The list of retrieved mock resources.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockResourceReduced"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         },
-        "description": "The paginated list of mock resources."
+        "description" : "The paginated list of mock resources."
       },
-      "MockResourceReduced": {
-        "required": [
-          "http_method",
-          "is_active",
-          "name",
-          "subsystem",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock resource.",
-            "example": "fb5363bcf68f687c9caeddbc221769f6"
+      "MockResourceReduced" : {
+        "required" : [ "http_method", "is_active", "name", "subsystem", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock resource.",
+            "example" : "fb5363bcf68f687c9caeddbc221769f6"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the mock resource is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the mock resource is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
+            "example" : "organizations/77777777777"
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the mock resource.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the mock resource.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "special_headers": {
-            "type": "array",
-            "description": "The special headers that can be added to a request in order to better reference a mock resource.",
-            "items": {
-              "$ref": "#/components/schemas/SpecialRequestHeader"
+          "special_headers" : {
+            "type" : "array",
+            "description" : "The special headers that can be added to a request in order to better reference a mock resource.",
+            "items" : {
+              "$ref" : "#/components/schemas/SpecialRequestHeader"
             }
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
             }
           }
         },
-        "description": "The mock resource main info."
+        "description" : "The mock resource main info."
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
           }
         },
-        "description": "The information related to the result page."
+        "description" : "The information related to the result page."
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the application."
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the application."
           },
-          "version": {
-            "type": "string",
-            "description": "The version related to the installed application."
+          "version" : {
+            "type" : "string",
+            "description" : "The version related to the installed application."
           },
-          "environment": {
-            "type": "string",
-            "description": "The environment tag on which the application is installed."
+          "environment" : {
+            "type" : "string",
+            "description" : "The environment tag on which the application is installed."
           },
-          "db_connection": {
-            "type": "string",
-            "description": "The status related to the database connection.",
-            "enum": [
-              "up",
-              "down"
-            ]
+          "db_connection" : {
+            "type" : "string",
+            "description" : "The status related to the database connection.",
+            "enum" : [ "up", "down" ]
           }
         }
       },
-      "ArchetypeList": {
-        "required": [
-          "page_info",
-          "resources"
-        ],
-        "type": "object",
-        "properties": {
-          "resources": {
-            "type": "array",
-            "description": "The list of retrieved archetypes.",
-            "items": {
-              "$ref": "#/components/schemas/Archetype"
+      "ArchetypeList" : {
+        "required" : [ "page_info", "resources" ],
+        "type" : "object",
+        "properties" : {
+          "resources" : {
+            "type" : "array",
+            "description" : "The list of retrieved archetypes.",
+            "items" : {
+              "$ref" : "#/components/schemas/Archetype"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         },
-        "description": "The paginated list of archetypes."
+        "description" : "The paginated list of archetypes."
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       },
-      "Authorization": {
-        "type": "http",
-        "description": "JWT token get after Azure Login",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "Authorization" : {
+        "type" : "http",
+        "description" : "JWT token get after Azure Login",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
       }
     }
   }

--- a/src/main/java/it/gov/pagopa/mocker/config/controller/MockResourceController.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/controller/MockResourceController.java
@@ -33,7 +33,8 @@ import javax.validation.constraints.*;
 @Validated
 public class MockResourceController {
 
-    @Autowired private ModelMapper modelMapper;
+    @Autowired
+    private ModelMapper modelMapper;
 
     @Autowired
     private MockResourceService mockResourceService;
@@ -51,15 +52,19 @@ public class MockResourceController {
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @GetMapping(value = "", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<MockResourceList> getMockResources(
             @Parameter(description = "The number of elements to be included in the page.", required = true)
             @Valid @RequestParam(required = false, defaultValue = "10") @Positive @Max(999) Integer limit,
             @Parameter(description = "The index of the page, starting from 0.", required = true)
-            @Valid @Min(0) @RequestParam(required = false, defaultValue = "0") Integer page) {
-        return ResponseEntity.ok(mockResourceService.getMockResources(PageRequest.of(page, limit)));
+            @Valid @Min(0) @RequestParam(required = false, defaultValue = "0") Integer page,
+            @Parameter(description = "The name of the mock resource, used as a search filter.")
+            @RequestParam(required = false) String name,
+            @Parameter(description = "The tag of the mock resource, used as a search filter.")
+            @RequestParam(required = false) String tag) {
+        return ResponseEntity.ok(mockResourceService.getMockResources(PageRequest.of(page, limit), name, tag));
     }
 
     @Operation(
@@ -76,7 +81,7 @@ public class MockResourceController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @GetMapping(value = "/{resourceId}", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<MockResource> getMockResource(
@@ -100,7 +105,7 @@ public class MockResourceController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @PostMapping(value = "", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<MockResource> createMockResource(
@@ -123,7 +128,7 @@ public class MockResourceController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @PostMapping(value = "/{resourceId}/rules", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<MockResource> createMockRule(
@@ -148,7 +153,7 @@ public class MockResourceController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @PutMapping(value = "/{resourceId}", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<MockResource> updateMockResource(
@@ -173,7 +178,7 @@ public class MockResourceController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @PutMapping(value = "/{resourceId}/general-info", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<MockResource> updateMockResourceGeneralInfo(
@@ -198,7 +203,7 @@ public class MockResourceController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @PutMapping(value = "/{resourceId}/rules/{ruleId}", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<MockResource> updateMockRule(
@@ -224,7 +229,7 @@ public class MockResourceController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ProblemJson.class))),
             @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
-            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,schema = @Schema(implementation = ProblemJson.class)))
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
     })
     @DeleteMapping(value = "/{resourceId}", produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<Void> deleteMockResource(

--- a/src/main/java/it/gov/pagopa/mocker/config/repository/MockResourceRepository.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/repository/MockResourceRepository.java
@@ -1,18 +1,14 @@
 package it.gov.pagopa.mocker.config.repository;
 
 import it.gov.pagopa.mocker.config.entity.MockResourceEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import it.gov.pagopa.mocker.config.repository.specification.MockResourceCriteriaRepository;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface MockResourceRepository extends MongoRepository<MockResourceEntity, String> {
-
-
-    Page<MockResourceEntity> findAll(Pageable pageable);
+public interface MockResourceRepository extends MongoRepository<MockResourceEntity, String>, MockResourceCriteriaRepository {
 
     Optional<MockResourceEntity> findById(String id);
 }

--- a/src/main/java/it/gov/pagopa/mocker/config/repository/specification/MockResourceCriteriaRepository.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/repository/specification/MockResourceCriteriaRepository.java
@@ -1,0 +1,10 @@
+package it.gov.pagopa.mocker.config.repository.specification;
+
+import it.gov.pagopa.mocker.config.entity.MockResourceEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MockResourceCriteriaRepository {
+
+    Page<MockResourceEntity> findAll(Pageable pageable, String name, String tag);
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/repository/specification/MockResourceCriteriaRepositoryImpl.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/repository/specification/MockResourceCriteriaRepositoryImpl.java
@@ -1,0 +1,37 @@
+package it.gov.pagopa.mocker.config.repository.specification;
+
+import it.gov.pagopa.mocker.config.entity.MockResourceEntity;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.List;
+
+public class MockResourceCriteriaRepositoryImpl implements MockResourceCriteriaRepository {
+
+
+    private final MongoTemplate mongoTemplate;
+
+    public MockResourceCriteriaRepositoryImpl(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public Page<MockResourceEntity> findAll(Pageable pageable, String name, String tag) {
+        Query query = new Query().with(pageable);
+        if (StringUtils.isNotEmpty(name)) {
+            query.addCriteria(Criteria.where("name").regex(".*" + name + ".*", "i"));
+        }
+        if (StringUtils.isNotEmpty(tag)) {
+            query.addCriteria(Criteria.where("tags").regex("(" + tag + ")", "i"));
+
+        }
+        List<MockResourceEntity> list = mongoTemplate.find(query, MockResourceEntity.class);
+        long count = mongoTemplate.count(query, MockResourceEntity.class);
+        return new PageImpl<>(list, pageable, count);
+    }
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/service/MockResourceService.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/service/MockResourceService.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -33,14 +32,14 @@ public class MockResourceService {
     @Autowired
     private ModelMapper modelMapper;
 
-    public MockResourceList getMockResources(Pageable pageable) {
+    public MockResourceList getMockResources(Pageable pageable, String name, String tag) {
         List<MockResourceReduced> mockResources;
         Page<MockResourceEntity> mockResourcePaginatedEntities;
         try {
-            mockResourcePaginatedEntities = mockResourceRepository.findAll(pageable);
+            mockResourcePaginatedEntities = mockResourceRepository.findAll(pageable, name, tag);
             mockResources = mockResourcePaginatedEntities.stream()
                     .map(mockResource -> modelMapper.map(mockResource, MockResourceReduced.class))
-                    .collect(Collectors.toList());
+                    .toList();
         } catch (DataAccessException e) {
             log.error("An error occurred while trying to retrieve a list of mock resources. ", e);
             throw new AppException(AppError.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
This PR contains a new functionality made on mock resource research operation. This new functionality aims to help the pagoPA Shared Toolbox portal on search operation, in order to guarantee a better user experience.  
Also, the automatic update of Terraform resources with dedicated GitHub pipeline is removed because there is an issue with the use of wrong authorization token, caused by the migration of infrastructure's apply strategy to managed-identity mode.

#### List of Changes
 - Added optional filters for filtering elements during mock resource read-all invocation
 - Temporarily removed Terraform's OpenAPI automatic update

#### Motivation and Context
This change permits to filtering mock resources based on specified fields

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.