### PR TITLE
feat: add script execution after the rule validation

### DIFF
--- a/.github/workflows/04_release_deploy.yml
+++ b/.github/workflows/04_release_deploy.yml
@@ -15,7 +15,6 @@ on:
         options:
           - dev
           - uat
-          - prod
       version:
         required: false
         type: choice

--- a/.identity/.terraform.lock.hcl
+++ b/.identity/.terraform.lock.hcl
@@ -41,25 +41,6 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.2"
-  hashes = [
-    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
-    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
-    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
-    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
-    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
-    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
-    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
-    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
-    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
-    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
-    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
-  ]
-}
-
 provider "registry.terraform.io/integrations/github" {
   version     = "5.18.3"
   constraints = "5.18.3"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,2915 +1,2872 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "pagoPA Mocker Configurator",
-    "description": "A service that permits to configure the mocked responses used by Mocker service",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.5"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "pagoPA Mocker Configurator",
+    "description" : "A service that permits to configure the mocked responses used by Mocker service",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "1.2.5"
   },
-  "servers": [
-    {
-      "url": "http://localhost:8080"
-    },
-    {
-      "url": "https://{host}{basePath}",
-      "variables": {
-        "host": {
-          "default": "api.dev.platform.pagopa.it",
-          "enum": [
-            "api.dev.platform.pagopa.it",
-            "api.uat.platform.pagopa.it"
-          ]
-        },
-        "basePath": {
-          "default": "/mocker-config/api/v1",
-          "enum": [
-            "/mocker-config/auth/api/v1",
-            "/mocker-config/api/v1"
-          ]
-        }
+  "servers" : [ {
+    "url" : "http://localhost:8080"
+  }, {
+    "url" : "https://{host}{basePath}",
+    "variables" : {
+      "host" : {
+        "default" : "api.dev.platform.pagopa.it",
+        "enum" : [ "api.dev.platform.pagopa.it", "api.uat.platform.pagopa.it" ]
+      },
+      "basePath" : {
+        "default" : "/mocker-config/api/v1",
+        "enum" : [ "/mocker-config/auth/api/v1", "/mocker-config/api/v1" ]
       }
     }
-  ],
-  "tags": [
-    {
-      "name": "Archetypes",
-      "description": "Everything about Archetypes"
-    },
-    {
-      "name": "Mock Resources",
-      "description": "Everything about Mock Resources"
-    }
-  ],
-  "paths": {
-    "/archetypes": {
-      "get": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Get paginated list of archetypes",
-        "operationId": "getArchetypes",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+  } ],
+  "tags" : [ {
+    "name" : "Archetypes",
+    "description" : "Everything about Archetypes"
+  }, {
+    "name" : "Mock Resources",
+    "description" : "Everything about Mock Resources"
+  } ],
+  "paths" : {
+    "/archetypes" : {
+      "get" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Get paginated list of archetypes",
+        "operationId" : "getArchetypes",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchetypeList"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArchetypeList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create a new archetype",
-        "operationId": "createArchetype",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Archetype"
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create a new archetype",
+        "operationId" : "createArchetype",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Archetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Delete all existing archetypes by criteria",
-        "operationId": "deleteMockResource_1",
-        "parameters": [
-          {
-            "name": "subsystem",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Delete all existing archetypes by criteria",
+        "operationId" : "deleteMockResource_1",
+        "parameters" : [ {
+          "name" : "subsystem",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {}
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/import": {
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create multiple archetypes from OpenAPI specification",
-        "operationId": "importArchetypesFromOpenAPI",
-        "parameters": [
-          {
-            "name": "subsystem",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/import" : {
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create multiple archetypes from OpenAPI specification",
+        "operationId" : "importArchetypesFromOpenAPI",
+        "parameters" : [ {
+          "name" : "subsystem",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "description": "JSON file containing the OpenAPI to analyze",
-                    "format": "binary"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "required" : [ "file" ],
+                "type" : "object",
+                "properties" : {
+                  "file" : {
+                    "type" : "string",
+                    "description" : "JSON file containing the OpenAPI to analyze",
+                    "format" : "binary"
                   }
                 }
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchetypeHandlingResult"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ArchetypeHandlingResult"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/{archetypeId}": {
-      "get": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Get detail of a single archetype",
-        "operationId": "getArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/{archetypeId}" : {
+      "get" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Get detail of a single archetype",
+        "operationId" : "getArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Update an existing archetype",
-        "operationId": "updateArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Update an existing archetype",
+        "operationId" : "updateArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Archetype"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Archetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Archetype"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Archetype"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/archetypes/{archetypeId}/generate": {
-      "post": {
-        "tags": [
-          "Archetypes"
-        ],
-        "summary": "Create a new mock resource starting from archetype",
-        "operationId": "createMockResourceFromArchetype",
-        "parameters": [
-          {
-            "name": "archetypeId",
-            "in": "path",
-            "description": "The identifier related to the archetype",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/archetypes/{archetypeId}/generate" : {
+      "post" : {
+        "tags" : [ "Archetypes" ],
+        "summary" : "Create a new mock resource starting from archetype",
+        "operationId" : "createMockResourceFromArchetype",
+        "parameters" : [ {
+          "name" : "archetypeId",
+          "in" : "path",
+          "description" : "The identifier related to the archetype",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResourceFromArchetype"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResourceFromArchetype"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return the application running status",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return the application running status",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources": {
-      "get": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Get paginated list of mock resource",
-        "operationId": "getMockResources",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
-          },
-          {
-            "name": "name",
-            "in": "query",
-            "description": "The name of the mock resource, used as a search filter.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "tag",
-            "in": "query",
-            "description": "The tag of the mock resource, used as a search filter.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
+    "/resources" : {
+      "get" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Get paginated list of mock resource",
+        "operationId" : "getMockResources",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        }, {
+          "name" : "name",
+          "in" : "query",
+          "description" : "The name of the mock resource, used as a search filter.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "tag",
+          "in" : "query",
+          "description" : "The tag of the mock resource, used as a search filter.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResourceList"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResourceList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Create a new mock resource",
-        "operationId": "createMockResource",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResource"
+      "post" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Create a new mock resource",
+        "operationId" : "createMockResource",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResource"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}": {
-      "get": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Get detail of a single mock resource",
-        "operationId": "getMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}" : {
+      "get" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Get detail of a single mock resource",
+        "operationId" : "getMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Update an existing mock resource",
-        "operationId": "updateMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Update an existing mock resource",
+        "operationId" : "updateMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResource"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResource"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Delete an existing mock resource",
-        "operationId": "deleteMockResource",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Delete an existing mock resource",
+        "operationId" : "deleteMockResource",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "204": {
-            "description": "No content",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/general-info": {
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Partially update an existing mock resource, changing only the general info",
-        "operationId": "updateMockResourceGeneralInfo",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/general-info" : {
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Partially update an existing mock resource, changing only the general info",
+        "operationId" : "updateMockResourceGeneralInfo",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockResourceGeneralInfo"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockResourceGeneralInfo"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/rules": {
-      "post": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Create a new mock rule for certain mock resource",
-        "operationId": "createMockRule",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/rules" : {
+      "post" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Create a new mock rule for certain mock resource",
+        "operationId" : "createMockRule",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockRule"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockRule"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "409" : {
+            "description" : "Conflict",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/resources/{resourceId}/rules/{ruleId}": {
-      "put": {
-        "tags": [
-          "Mock Resources"
-        ],
-        "summary": "Update an existing mock rule for certain mock resource",
-        "operationId": "updateMockRule",
-        "parameters": [
-          {
-            "name": "resourceId",
-            "in": "path",
-            "description": "The identifier related to the mock resource",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ruleId",
-            "in": "path",
-            "description": "The identifier related to the mock rule",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/resources/{resourceId}/rules/{ruleId}" : {
+      "put" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Update an existing mock rule for certain mock resource",
+        "operationId" : "updateMockRule",
+        "parameters" : [ {
+          "name" : "resourceId",
+          "in" : "path",
+          "description" : "The identifier related to the mock resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MockRule"
+        }, {
+          "name" : "ruleId",
+          "in" : "path",
+          "description" : "The identifier related to the mock rule",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MockRule"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MockResource"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/MockResource"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "Not Found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          },
-          {
-            "Authorization": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
+    },
+    "/scripting" : {
+      "get" : {
+        "tags" : [ "Mock Resources" ],
+        "summary" : "Get complete list of scripts",
+        "operationId" : "getScripts",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "description" : "The name of the script, used as a search filter.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ScriptMetadataList"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "MockCondition": {
-        "required": [
-          "analyzed_content_type",
-          "condition_type",
-          "field_name",
-          "field_position",
-          "order"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock condition.",
-            "example": "6b0b003d-74f4-428e-b950-61f42e02bf07"
+  "components" : {
+    "schemas" : {
+      "MockCondition" : {
+        "required" : [ "analyzed_content_type", "condition_type", "field_name", "field_position", "order" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock condition.",
+            "example" : "6b0b003d-74f4-428e-b950-61f42e02bf07"
           },
-          "order": {
-            "type": "integer",
-            "description": "The cardinal order on which the mock condition will be evaluated by Mocker.",
-            "format": "int32",
-            "example": 1
+          "order" : {
+            "type" : "integer",
+            "description" : "The cardinal order on which the mock condition will be evaluated by Mocker.",
+            "format" : "int32",
+            "example" : 1
           },
-          "field_position": {
-            "type": "string",
-            "description": "The parameter that define where the field/element that will be evaluated by this condition is located in the request.",
-            "example": "BODY",
-            "enum": [
-              "BODY",
-              "HEADER",
-              "URL"
-            ]
+          "field_position" : {
+            "type" : "string",
+            "description" : "The parameter that define where the field/element that will be evaluated by this condition is located in the request.",
+            "example" : "BODY",
+            "enum" : [ "BODY", "HEADER", "URL" ]
           },
-          "analyzed_content_type": {
-            "type": "string",
-            "description": "The parameter that define the type of the source in the request where the field/element that will be evaluated by this condition will be extracted.",
-            "example": "JSON",
-            "enum": [
-              "JSON",
-              "XML",
-              "STRING"
-            ]
+          "analyzed_content_type" : {
+            "type" : "string",
+            "description" : "The parameter that define the type of the source in the request where the field/element that will be evaluated by this condition will be extracted.",
+            "example" : "JSON",
+            "enum" : [ "JSON", "XML", "STRING" ]
           },
-          "field_name": {
-            "type": "string",
-            "description": "The parameter that define the identifier of the field/element that will be evaluated by this condition",
-            "example": "station.id"
+          "field_name" : {
+            "type" : "string",
+            "description" : "The parameter that define the identifier of the field/element that will be evaluated by this condition",
+            "example" : "station.id"
           },
-          "condition_type": {
-            "type": "string",
-            "description": "The parameter that define the type of condition that will be applied on the field/element that will be evaluated.",
-            "example": "EQ",
-            "enum": [
-              "REGEX",
-              "EQ",
-              "NEQ",
-              "LT",
-              "GT",
-              "LE",
-              "GE",
-              "NULL",
-              "ANY"
-            ]
+          "condition_type" : {
+            "type" : "string",
+            "description" : "The parameter that define the type of condition that will be applied on the field/element that will be evaluated.",
+            "example" : "EQ",
+            "enum" : [ "REGEX", "EQ", "NEQ", "LT", "GT", "LE", "GE", "NULL", "ANY" ]
           },
-          "condition_value": {
-            "type": "string",
-            "description": "The parameter that define the value that the field/element must respect following the condition type.",
-            "example": "77777777777_01"
+          "condition_value" : {
+            "type" : "string",
+            "description" : "The parameter that define the value that the field/element must respect following the condition type.",
+            "example" : "77777777777_01"
           }
         },
-        "description": "The condition applied to the mock rule that a request must respect in order to retrieve the mocked response related to the rule."
+        "description" : "The condition applied to the mock rule that a request must respect in order to retrieve the mocked response related to the rule."
       },
-      "MockResource": {
-        "required": [
-          "http_method",
-          "is_active",
-          "name",
-          "rules",
-          "special_headers",
-          "subsystem",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock resource.",
-            "example": "fb5363bcf68f687c9caeddbc221769f6"
+      "MockResource" : {
+        "required" : [ "http_method", "is_active", "name", "rules", "special_headers", "subsystem", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock resource.",
+            "example" : "fb5363bcf68f687c9caeddbc221769f6"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the mock resource is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the mock resource is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
+            "example" : "organizations/77777777777"
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the mock resource.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the mock resource.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "special_headers": {
-            "type": "array",
-            "description": "The special headers that can be added to a request in order to better reference a mock resource.",
-            "items": {
-              "$ref": "#/components/schemas/SpecialRequestHeader"
+          "special_headers" : {
+            "type" : "array",
+            "description" : "The special headers that can be added to a request in order to better reference a mock resource.",
+            "items" : {
+              "$ref" : "#/components/schemas/SpecialRequestHeader"
             }
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
             }
           },
-          "rules": {
-            "type": "array",
-            "description": "The list of rules related to the mock resource that will be evaluated by the Mocker.",
-            "items": {
-              "$ref": "#/components/schemas/MockRule"
+          "rules" : {
+            "type" : "array",
+            "description" : "The list of rules related to the mock resource that will be evaluated by the Mocker.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockRule"
             }
           }
         },
-        "description": "The mock resource, analyzed by Mocker, that permits to generate different responses based by rules and conditions."
+        "description" : "The mock resource, analyzed by Mocker, that permits to generate different responses based by rules and conditions."
       },
-      "MockResponse": {
-        "required": [
-          "headers",
-          "injected_parameters",
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock response",
-            "example": "26e05a1f-9621-4e24-a57d-28694ff30306"
+      "MockResponse" : {
+        "required" : [ "headers", "injected_parameters", "status" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock response",
+            "example" : "26e05a1f-9621-4e24-a57d-28694ff30306"
           },
-          "body": {
-            "type": "string",
-            "description": "The response body in Base64 format related to the mock response.",
-            "example": "eyJtZXNzYWdlIjoiT0shIn0="
+          "body" : {
+            "type" : "string",
+            "description" : "The response body in Base64 format related to the mock response.",
+            "example" : "eyJtZXNzYWdlIjoiT0shIn0="
           },
-          "status": {
-            "type": "integer",
-            "description": "The HTTP response status related to the mock response.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "type" : "integer",
+            "description" : "The HTTP response status related to the mock response.",
+            "format" : "int32",
+            "example" : 200
           },
-          "headers": {
-            "type": "array",
-            "description": "The list of header to be set to mock response.",
-            "items": {
-              "$ref": "#/components/schemas/ResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "description" : "The list of header to be set to mock response.",
+            "items" : {
+              "$ref" : "#/components/schemas/ResponseHeader"
             }
           },
-          "injected_parameters": {
-            "type": "array",
-            "description": "The list of parameters that will be injected from request body to response body by Mocker.",
-            "items": {
-              "type": "string",
-              "description": "The list of parameters that will be injected from request body to response body by Mocker."
+          "injected_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameters that will be injected from request body to response body by Mocker.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameters that will be injected from request body to response body by Mocker."
             }
           }
         },
-        "description": "The mocked response that will be generated by Mocker if the rule condition are all verified."
+        "description" : "The mocked response that will be generated by Mocker if the rule condition are all verified."
       },
-      "MockRule": {
-        "required": [
-          "conditions",
-          "is_active",
-          "name",
-          "order",
-          "response",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock rule",
-            "example": "6c08a21c-6a92-4f6b-a1e1-bf68c4e099c9"
+      "MockRule" : {
+        "required" : [ "conditions", "is_active", "name", "order", "response", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock rule",
+            "example" : "6c08a21c-6a92-4f6b-a1e1-bf68c4e099c9"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock rule, for human readability.",
-            "example": "Main rule"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock rule, for human readability.",
+            "example" : "Main rule"
           },
-          "order": {
-            "type": "integer",
-            "description": "The cardinal order on which the mock role will be evaluated by Mocker.",
-            "format": "int32",
-            "example": 1
+          "order" : {
+            "type" : "integer",
+            "description" : "The cardinal order on which the mock role will be evaluated by Mocker.",
+            "format" : "int32",
+            "example" : 1
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock rule for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock rule for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock rule is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock rule is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock rule is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock rule is related to."
             }
           },
-          "conditions": {
-            "type": "array",
-            "description": "The list of condition related to the mock rule that will be evaluated in AND by the Mocker.",
-            "items": {
-              "$ref": "#/components/schemas/MockCondition"
+          "conditions" : {
+            "type" : "array",
+            "description" : "The list of condition related to the mock rule that will be evaluated in AND by the Mocker.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockCondition"
             }
           },
-          "response": {
-            "$ref": "#/components/schemas/MockResponse"
+          "scripting" : {
+            "$ref" : "#/components/schemas/MockScripting"
+          },
+          "response" : {
+            "$ref" : "#/components/schemas/MockResponse"
           }
         },
-        "description": "The rule a passed request can follow in order to obtain the defined mocked response."
+        "description" : "The rule a passed request can follow in order to obtain the defined mocked response."
       },
-      "ResponseHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the header to be set to mock response by Mocker.",
-            "example": "Content-Type"
+      "MockScripting" : {
+        "required" : [ "input_parameters", "is_active", "script_name" ],
+        "type" : "object",
+        "properties" : {
+          "script_name" : {
+            "type" : "string",
+            "description" : "The name of the script that will be executed by the Mocker for the associated rule.",
+            "example" : "delay"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the header to be set to mock response by Mocker.",
-            "example": "application/json"
+          "description" : {
+            "type" : "string",
+            "description" : "The human-readable description that explains the behavior of the script.",
+            "example" : "Lorem ipsum sit dolorem"
+          },
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The flag that define if the scripting process is enabled for the associated rule.",
+            "example" : true
+          },
+          "input_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameters to be set as input for the execution of the script in the Mocker.",
+            "items" : {
+              "$ref" : "#/components/schemas/ScriptParameter"
+            }
+          },
+          "output_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameters that will be returned as output from the script during runtime.",
+            "example" : "dynamic.res",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameters that will be returned as output from the script during runtime.",
+              "example" : "dynamic.res"
+            }
           }
         },
-        "description": "The header that will be set to a mocked response"
+        "description" : "The information about the script to be executed by Mocker if all the conditions occurs."
       },
-      "SpecialRequestHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the special header to be set to request to retrieve mock response from Mocker.",
-            "example": "SOAPAction"
+      "ResponseHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the header to be set to mock response by Mocker.",
+            "example" : "Content-Type"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the special header to be set to request to retrieve mock response from Mocker.",
-            "example": "someSoapAction"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the header to be set to mock response by Mocker.",
+            "example" : "application/json"
           }
         },
-        "description": "The special header that can be added to a request in order to better reference a mock resource."
+        "description" : "The header that will be set to a mocked response"
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ScriptParameter" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the parameter to be set as input. In script, it will be retrieved wit the annotation parameters.FIELD_NAME.",
+            "example" : "some-param"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the parameter to be set as input. The value can be a constant or a dynamic value, retrievable from request body.",
+            "example" : "some-value"
+          }
+        },
+        "description" : "The parameter to be set as input for the execution of the script in the Mocker."
+      },
+      "SpecialRequestHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the special header to be set to request to retrieve mock response from Mocker.",
+            "example" : "SOAPAction"
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the special header to be set to request to retrieve mock response from Mocker.",
+            "example" : "someSoapAction"
+          }
+        },
+        "description" : "The special header that can be added to a request in order to better reference a mock resource."
+      },
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+          },
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "MockResourceGeneralInfo": {
-        "required": [
-          "is_active",
-          "name",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+      "MockResourceGeneralInfo" : {
+        "required" : [ "is_active", "name", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
             }
           }
         },
-        "description": "The general information about mock resource, used for partial update."
+        "description" : "The general information about mock resource, used for partial update."
       },
-      "Archetype": {
-        "required": [
-          "http_method",
-          "name",
-          "resource_url",
-          "responses",
-          "subsystem",
-          "tags",
-          "url_parameters"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the archetype.",
-            "example": "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
+      "Archetype" : {
+        "required" : [ "http_method", "name", "resource_url", "responses", "subsystem", "tags", "url_parameters" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the archetype.",
+            "example" : "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
           },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the archetype, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the archetype, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the archetype is related.",
-            "example": "apiconfig/api/v1"
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the archetype is related.",
+            "example" : "apiconfig/api/v1"
           },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the archetype will be defined for the subsystem.",
-            "example": "organizations/77777777777"
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the archetype will be defined for the subsystem.",
+            "example" : "organizations/77777777777"
           },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the archetype.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the archetype.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
           },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the archetype is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the archetype is related to."
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the archetype is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the archetype is related to."
             }
           },
-          "url_parameters": {
-            "type": "array",
-            "description": "The list of parameter related to the archetype URL that must be set in mock resource creation.",
-            "items": {
-              "type": "string",
-              "description": "The list of parameter related to the archetype URL that must be set in mock resource creation."
+          "url_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameter related to the archetype URL that must be set in mock resource creation.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameter related to the archetype URL that must be set in mock resource creation."
             }
           },
-          "responses": {
-            "type": "array",
-            "description": "The list of responses related to the archetype that can be edited in mock resource creation.",
-            "items": {
-              "$ref": "#/components/schemas/ArchetypeResponse"
+          "responses" : {
+            "type" : "array",
+            "description" : "The list of responses related to the archetype that can be edited in mock resource creation.",
+            "items" : {
+              "$ref" : "#/components/schemas/ArchetypeResponse"
             }
           }
         }
       },
-      "ArchetypeResponse": {
-        "required": [
-          "headers",
-          "injectable_parameters",
-          "status"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the archetype response.",
-            "example": "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
+      "ArchetypeResponse" : {
+        "required" : [ "headers", "injectable_parameters", "status" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the archetype response.",
+            "example" : "2ee0aafa-9a9a-901a-bbb1-33394ff201ad"
           },
-          "body": {
-            "type": "string"
+          "body" : {
+            "type" : "string"
           },
-          "status": {
-            "type": "integer",
-            "format": "int32"
+          "status" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "headers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ArchetypeResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ArchetypeResponseHeader"
             }
           },
-          "injectable_parameters": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "injectable_parameters" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           }
         },
-        "description": "The list of responses related to the archetype that can be edited in mock resource creation."
+        "description" : "The list of responses related to the archetype that can be edited in mock resource creation."
       },
-      "ArchetypeResponseHeader": {
-        "required": [
-          "name",
-          "value"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The key of the header to be set to archetype.",
-            "example": "Content-Type"
+      "ArchetypeResponseHeader" : {
+        "required" : [ "name", "value" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The key of the header to be set to archetype.",
+            "example" : "Content-Type"
           },
-          "value": {
-            "type": "string",
-            "description": "The value of the header to be set to archetype.",
-            "example": "application/json"
+          "value" : {
+            "type" : "string",
+            "description" : "The value of the header to be set to archetype.",
+            "example" : "application/json"
           }
         },
-        "description": "The header that will be set to a mocked response generated by the archetype"
+        "description" : "The header that will be set to a mocked response generated by the archetype"
       },
-      "MockResourceFromArchetype": {
-        "type": "object",
-        "properties": {
-          "is_active": {
-            "type": "boolean"
+      "MockResourceFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "is_active" : {
+            "type" : "boolean"
           },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "tags" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           },
-          "url_parameters": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StaticParameterValue"
+          "url_parameters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StaticParameterValue"
             }
           },
-          "rules": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MockRuleFromArchetype"
+          "rules" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MockRuleFromArchetype"
             }
           }
         }
       },
-      "MockResponseFromArchetype": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "integer",
-            "format": "int32"
+      "MockResponseFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "status" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "headers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ResponseHeader"
+          "headers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ResponseHeader"
             }
           },
-          "static_values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StaticParameterValue"
+          "static_values" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StaticParameterValue"
             }
           }
         }
       },
-      "MockRuleFromArchetype": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "MockRuleFromArchetype" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "order": {
-            "type": "integer",
-            "format": "int32"
+          "order" : {
+            "type" : "integer",
+            "format" : "int32"
           },
-          "is_active": {
-            "type": "boolean"
+          "is_active" : {
+            "type" : "boolean"
           },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "tags" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
             }
           },
-          "conditions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MockCondition"
+          "conditions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/MockCondition"
             }
           },
-          "response": {
-            "$ref": "#/components/schemas/MockResponseFromArchetype"
+          "response" : {
+            "$ref" : "#/components/schemas/MockResponseFromArchetype"
           }
         }
       },
-      "StaticParameterValue": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "StaticParameterValue" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "value": {
-            "type": "string"
+          "value" : {
+            "type" : "string"
           }
         }
       },
-      "ArchetypeHandlingResult": {
-        "type": "object",
-        "properties": {
-          "subsystem_url": {
-            "type": "string"
+      "ArchetypeHandlingResult" : {
+        "type" : "object",
+        "properties" : {
+          "subsystem_url" : {
+            "type" : "string"
           },
-          "generated_archetypes": {
-            "type": "integer",
-            "format": "int32"
+          "generated_archetypes" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },
-      "MockResourceList": {
-        "required": [
-          "page_info",
-          "resources"
-        ],
-        "type": "object",
-        "properties": {
-          "resources": {
-            "type": "array",
-            "description": "The list of retrieved mock resources.",
-            "items": {
-              "$ref": "#/components/schemas/MockResourceReduced"
+      "ScriptMetadata" : {
+        "required" : [ "description", "input_parameters", "name", "output_parameters" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the script.",
+            "example" : "fb5363bcf68f687c9caeddbc221769f6"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the script.",
+            "example" : "delay"
+          },
+          "description" : {
+            "type" : "string",
+            "description" : "The human-readable description that explains the behavior of the script.",
+            "example" : "Lorem ipsum sit dolorem"
+          },
+          "input_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameters to be passed as input to the script during runtime.",
+            "example" : "name",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameters to be passed as input to the script during runtime.",
+              "example" : "name"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
-          }
-        },
-        "description": "The paginated list of mock resources."
-      },
-      "MockResourceReduced": {
-        "required": [
-          "http_method",
-          "is_active",
-          "name",
-          "subsystem",
-          "tags"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique identifier of the mock resource.",
-            "example": "fb5363bcf68f687c9caeddbc221769f6"
-          },
-          "name": {
-            "type": "string",
-            "description": "The name or description related to the mock resources, for human readability.",
-            "example": "Get enrolled organization with ID 77777777777"
-          },
-          "subsystem": {
-            "type": "string",
-            "description": "The URL section that define the subsystem on which the mock resource is related.",
-            "example": "apiconfig/api/v1"
-          },
-          "resource_url": {
-            "type": "string",
-            "description": "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
-            "example": "organizations/77777777777"
-          },
-          "http_method": {
-            "type": "string",
-            "description": "The HTTP method related to the mock resource.",
-            "example": "GET",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "PATCH",
-              "OPTIONS",
-              "TRACE"
-            ]
-          },
-          "special_headers": {
-            "type": "array",
-            "description": "The special headers that can be added to a request in order to better reference a mock resource.",
-            "items": {
-              "$ref": "#/components/schemas/SpecialRequestHeader"
-            }
-          },
-          "is_active": {
-            "type": "boolean",
-            "description": "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
-            "example": true
-          },
-          "tags": {
-            "type": "array",
-            "description": "The set of tags on which the mock resource is related to.",
-            "items": {
-              "type": "string",
-              "description": "The set of tags on which the mock resource is related to."
+          "output_parameters" : {
+            "type" : "array",
+            "description" : "The list of parameters that will be returned as output from the script during runtime.",
+            "example" : "dynamic.res",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of parameters that will be returned as output from the script during runtime.",
+              "example" : "dynamic.res"
             }
           }
         },
-        "description": "The mock resource main info."
+        "description" : "The script that can be executed by Mocker and that permits to generate dynamic values based on scripted execution."
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_items",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "Page number",
-            "format": "int32"
-          },
-          "limit": {
-            "type": "integer",
-            "description": "Required number of items per page",
-            "format": "int32"
-          },
-          "items_found": {
-            "type": "integer",
-            "description": "Number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
-          },
-          "total_pages": {
-            "type": "integer",
-            "description": "Total number of pages",
-            "format": "int32"
-          },
-          "total_items": {
-            "type": "integer",
-            "description": "Total number of items for all pages",
-            "format": "int64"
+      "ScriptMetadataList" : {
+        "required" : [ "scripts" ],
+        "type" : "object",
+        "properties" : {
+          "scripts" : {
+            "type" : "array",
+            "description" : "The list of retrieved scripts.",
+            "items" : {
+              "$ref" : "#/components/schemas/ScriptMetadata"
+            }
           }
         },
-        "description": "The information related to the result page."
+        "description" : "The complete list of scripts to be used for dynamic mock behavior."
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the application."
+      "MockResourceList" : {
+        "required" : [ "page_info", "resources" ],
+        "type" : "object",
+        "properties" : {
+          "resources" : {
+            "type" : "array",
+            "description" : "The list of retrieved mock resources.",
+            "items" : {
+              "$ref" : "#/components/schemas/MockResourceReduced"
+            }
           },
-          "version": {
-            "type": "string",
-            "description": "The version related to the installed application."
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
+          }
+        },
+        "description" : "The paginated list of mock resources."
+      },
+      "MockResourceReduced" : {
+        "required" : [ "http_method", "is_active", "name", "subsystem", "tags" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The unique identifier of the mock resource.",
+            "example" : "fb5363bcf68f687c9caeddbc221769f6"
           },
-          "environment": {
-            "type": "string",
-            "description": "The environment tag on which the application is installed."
+          "name" : {
+            "type" : "string",
+            "description" : "The name or description related to the mock resources, for human readability.",
+            "example" : "Get enrolled organization with ID 77777777777"
           },
-          "db_connection": {
-            "type": "string",
-            "description": "The status related to the database connection.",
-            "enum": [
-              "up",
-              "down"
-            ]
+          "subsystem" : {
+            "type" : "string",
+            "description" : "The URL section that define the subsystem on which the mock resource is related.",
+            "example" : "apiconfig/api/v1"
+          },
+          "resource_url" : {
+            "type" : "string",
+            "description" : "The specific URL on which the mock resource will be defined for the subsystem. If no specific URL is needed, use blank string.",
+            "example" : "organizations/77777777777"
+          },
+          "http_method" : {
+            "type" : "string",
+            "description" : "The HTTP method related to the mock resource.",
+            "example" : "GET",
+            "enum" : [ "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "TRACE" ]
+          },
+          "special_headers" : {
+            "type" : "array",
+            "description" : "The special headers that can be added to a request in order to better reference a mock resource.",
+            "items" : {
+              "$ref" : "#/components/schemas/SpecialRequestHeader"
+            }
+          },
+          "is_active" : {
+            "type" : "boolean",
+            "description" : "The status flag that permits to activate or not the mock resource for Mocker evaluation.",
+            "example" : true
+          },
+          "tags" : {
+            "type" : "array",
+            "description" : "The set of tags on which the mock resource is related to.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of tags on which the mock resource is related to."
+            }
+          }
+        },
+        "description" : "The mock resource main info."
+      },
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_items", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "Page number",
+            "format" : "int32"
+          },
+          "limit" : {
+            "type" : "integer",
+            "description" : "Required number of items per page",
+            "format" : "int32"
+          },
+          "items_found" : {
+            "type" : "integer",
+            "description" : "Number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
+          },
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "Total number of pages",
+            "format" : "int32"
+          },
+          "total_items" : {
+            "type" : "integer",
+            "description" : "Total number of items for all pages",
+            "format" : "int64"
+          }
+        },
+        "description" : "The information related to the result page."
+      },
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the application."
+          },
+          "version" : {
+            "type" : "string",
+            "description" : "The version related to the installed application."
+          },
+          "environment" : {
+            "type" : "string",
+            "description" : "The environment tag on which the application is installed."
+          },
+          "db_connection" : {
+            "type" : "string",
+            "description" : "The status related to the database connection.",
+            "enum" : [ "up", "down" ]
           }
         }
       },
-      "ArchetypeList": {
-        "required": [
-          "page_info",
-          "resources"
-        ],
-        "type": "object",
-        "properties": {
-          "resources": {
-            "type": "array",
-            "description": "The list of retrieved archetypes.",
-            "items": {
-              "$ref": "#/components/schemas/Archetype"
+      "ArchetypeList" : {
+        "required" : [ "page_info", "resources" ],
+        "type" : "object",
+        "properties" : {
+          "resources" : {
+            "type" : "array",
+            "description" : "The list of retrieved archetypes.",
+            "items" : {
+              "$ref" : "#/components/schemas/Archetype"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         },
-        "description": "The paginated list of archetypes."
+        "description" : "The paginated list of archetypes."
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       },
-      "Authorization": {
-        "type": "http",
-        "description": "JWT token get after Azure Login",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "Authorization" : {
+        "type" : "http",
+        "description" : "JWT token get after Azure Login",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
       }
     }
   }

--- a/src/main/java/it/gov/pagopa/mocker/config/config/MappingsConfiguration.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/config/MappingsConfiguration.java
@@ -3,11 +3,13 @@ package it.gov.pagopa.mocker.config.config;
 import it.gov.pagopa.mocker.config.entity.ArchetypeEntity;
 import it.gov.pagopa.mocker.config.entity.MockResourceEntity;
 import it.gov.pagopa.mocker.config.entity.MockRuleEntity;
+import it.gov.pagopa.mocker.config.entity.ScriptEntity;
 import it.gov.pagopa.mocker.config.mapper.*;
 import it.gov.pagopa.mocker.config.model.archetype.Archetype;
 import it.gov.pagopa.mocker.config.model.mockresource.MockResource;
 import it.gov.pagopa.mocker.config.model.mockresource.MockResourceReduced;
 import it.gov.pagopa.mocker.config.model.mockresource.MockRule;
+import it.gov.pagopa.mocker.config.model.script.ScriptMetadata;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
@@ -16,19 +18,20 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class MappingsConfiguration {
 
-  @Bean
-  ModelMapper modelMapper() {
-    ModelMapper mapper = new ModelMapper();
-    mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+    @Bean
+    ModelMapper modelMapper() {
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
 
-    // insert here the new mappers
-    mapper.createTypeMap(MockResourceEntity.class, MockResource.class).setConverter(new ConvertMockResourceEntityToMockResource());
-    mapper.createTypeMap(MockResourceEntity.class, MockResourceReduced.class).setConverter(new ConvertMockResourceEntityToMockResourceReduced());
-    mapper.createTypeMap(MockResource.class, MockResourceEntity.class).setConverter(new ConvertMockResourceToMockResourceEntity());
-    mapper.createTypeMap(MockRule.class, MockRuleEntity.class).setConverter(new ConvertMockRuleToMockRuleEntity());
-    mapper.createTypeMap(ArchetypeEntity.class, Archetype.class).setConverter(new ConvertArchetypeEntityToArchetype());
+        // insert here the new mappers
+        mapper.createTypeMap(MockResourceEntity.class, MockResource.class).setConverter(new ConvertMockResourceEntityToMockResource());
+        mapper.createTypeMap(MockResourceEntity.class, MockResourceReduced.class).setConverter(new ConvertMockResourceEntityToMockResourceReduced());
+        mapper.createTypeMap(MockResource.class, MockResourceEntity.class).setConverter(new ConvertMockResourceToMockResourceEntity());
+        mapper.createTypeMap(ScriptEntity.class, ScriptMetadata.class).setConverter(new ConvertScriptEntityToScriptMetadata());
+        mapper.createTypeMap(MockRule.class, MockRuleEntity.class).setConverter(new ConvertMockRuleToMockRuleEntity());
+        mapper.createTypeMap(ArchetypeEntity.class, Archetype.class).setConverter(new ConvertArchetypeEntityToArchetype());
 
-    //
-    return mapper;
-  }
+        //
+        return mapper;
+    }
 }

--- a/src/main/java/it/gov/pagopa/mocker/config/controller/ScriptingController.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/controller/ScriptingController.java
@@ -1,0 +1,58 @@
+package it.gov.pagopa.mocker.config.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import it.gov.pagopa.mocker.config.model.ProblemJson;
+import it.gov.pagopa.mocker.config.model.script.ScriptMetadataList;
+import it.gov.pagopa.mocker.config.service.ScriptingService;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController()
+@RequestMapping(path = "/scripting")
+@Tag(name = "Mock Resources", description = "Everything about Mock Resources")
+@Validated
+public class ScriptingController {
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @Autowired
+    private ScriptingService scriptingService;
+
+    @Operation(
+            summary = "Get complete list of scripts",
+            security = {
+                    @SecurityRequirement(name = "ApiKey"),
+                    @SecurityRequirement(name = "Authorization")
+            },
+            tags = {"Mock Resources"}
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ScriptMetadataList.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
+            @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
+    })
+    @GetMapping(value = "", produces = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<ScriptMetadataList> getScripts(
+            @Parameter(description = "The name of the script, used as a search filter.")
+            @RequestParam(required = false) String name) {
+        return ResponseEntity.ok(scriptingService.getScripts(name));
+    }
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/entity/MockResourceEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/entity/MockResourceEntity.java
@@ -28,7 +28,7 @@ public class MockResourceEntity implements Serializable {
 
     private HttpMethod httpMethod;
 
-    private List<SpecialRequestHeaderEntity> specialHeaders;
+    private List<NameValueEntity> specialHeaders;
 
     private Boolean isActive;
 

--- a/src/main/java/it/gov/pagopa/mocker/config/entity/MockRuleEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/entity/MockRuleEntity.java
@@ -1,6 +1,9 @@
 package it.gov.pagopa.mocker.config.entity;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.List;
@@ -25,4 +28,6 @@ public class MockRuleEntity implements Serializable {
     private List<MockConditionEntity> conditions;
 
     private MockResponseEntity response;
+
+    private ScriptingEntity scripting;
 }

--- a/src/main/java/it/gov/pagopa/mocker/config/entity/NameValueEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/entity/NameValueEntity.java
@@ -11,7 +11,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-public class SpecialRequestHeaderEntity implements Serializable {
+public class NameValueEntity implements Serializable {
 
     private String name;
 

--- a/src/main/java/it/gov/pagopa/mocker/config/entity/ScriptEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/entity/ScriptEntity.java
@@ -1,0 +1,34 @@
+package it.gov.pagopa.mocker.config.entity;
+
+
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import javax.persistence.Id;
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@Document("scripts")
+@ToString
+public class ScriptEntity implements Serializable {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private String description;
+
+    private Boolean selectable;
+
+    private List<String> inputParameters;
+
+    private List<String> outputParameters;
+
+    private String code;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/entity/ScriptingEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/entity/ScriptingEntity.java
@@ -1,0 +1,22 @@
+package it.gov.pagopa.mocker.config.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class ScriptingEntity implements Serializable {
+
+    private String scriptName;
+
+    private Boolean isActive;
+
+    private List<NameValueEntity> parameters;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/exception/AppError.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/exception/AppError.java
@@ -8,39 +8,40 @@ import org.springframework.http.HttpStatus;
 public enum AppError {
 
 
-  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "Something went wrong."),
-  ARCHETYPE_CONFLICT(HttpStatus.CONFLICT, "Archetype already exists", "Another archetype exists for resource [%s %s%s]."),
-  ARCHETYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "Archetype not found", "No valid archetype found with id [%s]."),
-  ARCHETYPE_BAD_REQUEST_MISSING_URL_PARAMETER(HttpStatus.BAD_REQUEST, "Missing URL parameter", "The request must provide all the path parameters defined by the archetype URL: %s"),
-  ARCHETYPE_BAD_REQUEST_MULTIPLE_RESPONSE_WITH_SAME_HTTPCODE(HttpStatus.BAD_REQUEST, "Duplicated responses", "There are multiple responses that refers to the same HTTP status."),
-  ARCHETYPE_BAD_REQUEST_INVALID_RESOURCE_URL(HttpStatus.BAD_REQUEST, "Invalid archetype URL", "The subsystem or the resource URL passed as input is different from the values defined in the archetype to be edited and cannot be changed."),
-  MOCK_RESOURCE_BAD_REQUEST_INVALID_RESOURCE_ID(HttpStatus.BAD_REQUEST, "Invalid mock resource identifier", "The passed resource id with value [%s] must be equals to the one defined from request ([%s])."),
-  MOCK_RESOURCE_BAD_REQUEST_INVALID_RESOURCE_URL(HttpStatus.BAD_REQUEST, "Invalid mock resource URL", "The subsystem or the resource URL passed as input is different from the values defined in the resource to be edited and cannot be changed."),
-  MOCK_RESOURCE_BAD_REQUEST_DUPLICATE_RULE_ORDER(HttpStatus.BAD_REQUEST, "Duplicated mock rule cardinal order", "One or more cardinal order value for the passed mock rules are duplicated."),
-  MOCK_RESOURCE_BAD_REQUEST_DUPLICATE_CONDITION_ORDER(HttpStatus.BAD_REQUEST, "Duplicated mock condition cardinal order", "One or more cardinal order value for the mock condition related to the rules [%s] are duplicated."),
-  MOCK_RESOURCE_BAD_REQUEST_INVALID_UNARY_CONDITION(HttpStatus.BAD_REQUEST, "Invalid unary condition", "The unary condition for mock rule [%s] at order [%d] is set with a condition value but it must be set with null value."),
-  MOCK_RESOURCE_BAD_REQUEST_INVALID_BINARY_CONDITION(HttpStatus.BAD_REQUEST, "Invalid binary condition", "The binary condition for mock rule [%] at order [%d] is set without a condition value but it must be set with non-null value."),
-  MOCK_RESOURCE_BAD_REQUEST_INVALID_REGEX(HttpStatus.BAD_REQUEST, "Invalid regex condition", "The regular expression set in the condition for mock rule [%] at order [%d] is invalid and cannot be used as valid value."),
-  MOCK_RESOURCE_BAD_REQUEST_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "Invalid content type in condition", "The content type of mock condition for mock rule [%] at order [%d] is set as [%s] but it is incompatible with [%s] content."),
-  MOCK_RESOURCE_BAD_REQUEST_UNPARSEABLE_RESPONSE_BODY(HttpStatus.BAD_REQUEST, "Invalid format for response body", "The response body related to the mock rule [%] is not passed as a valid Base64 content."),
-  MOCK_RESOURCE_CONFLICT(HttpStatus.CONFLICT, "Mock resource already exists", "Another mock resource exists with id [%s]."),
-  MOCK_RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Mock resource not found", "No valid mock resource found with id [%s]."),
-  MOCK_RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "Mock rule not found", "No valid mock rule with id [%s] was found for mock resource found with id [%s]."),
-  MOCK_RESOURCE_GENERATION_FROM_ARCHETYPE_INVALID_HTTPSTATUS(HttpStatus.BAD_REQUEST, "Invalid HTTP status", "No valid response defined in archetype for the HTTP status [%d]."),
-  MOCK_RESOURCE_GENERATION_FROM_ARCHETYPE_MISSING_URL_PARAMETER(HttpStatus.BAD_REQUEST, "Missing URL parameter", "The request must provide all the path parameters defined by the archetype: %s"),
-  OPENAPI_IMPORT_INVALID_FILE_CONTENT(HttpStatus.BAD_REQUEST, "Invalid OpenAPI file", "The passed OpenAPI file is invalid or malformed and cannot be analyzed.")
-  ;
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "Something went wrong."),
+    ARCHETYPE_CONFLICT(HttpStatus.CONFLICT, "Archetype already exists", "Another archetype exists for resource [%s %s%s]."),
+    ARCHETYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "Archetype not found", "No valid archetype found with id [%s]."),
+    ARCHETYPE_BAD_REQUEST_MISSING_URL_PARAMETER(HttpStatus.BAD_REQUEST, "Missing URL parameter", "The request must provide all the path parameters defined by the archetype URL: %s"),
+    ARCHETYPE_BAD_REQUEST_MULTIPLE_RESPONSE_WITH_SAME_HTTPCODE(HttpStatus.BAD_REQUEST, "Duplicated responses", "There are multiple responses that refers to the same HTTP status."),
+    ARCHETYPE_BAD_REQUEST_INVALID_RESOURCE_URL(HttpStatus.BAD_REQUEST, "Invalid archetype URL", "The subsystem or the resource URL passed as input is different from the values defined in the archetype to be edited and cannot be changed."),
+    MOCK_RESOURCE_BAD_REQUEST_INVALID_RESOURCE_ID(HttpStatus.BAD_REQUEST, "Invalid mock resource identifier", "The passed resource id with value [%s] must be equals to the one defined from request ([%s])."),
+    MOCK_RESOURCE_BAD_REQUEST_INVALID_RESOURCE_URL(HttpStatus.BAD_REQUEST, "Invalid mock resource URL", "The subsystem or the resource URL passed as input is different from the values defined in the resource to be edited and cannot be changed."),
+    MOCK_RESOURCE_BAD_REQUEST_DUPLICATE_RULE_ORDER(HttpStatus.BAD_REQUEST, "Duplicated mock rule cardinal order", "One or more cardinal order value for the passed mock rules are duplicated."),
+    MOCK_RESOURCE_BAD_REQUEST_DUPLICATE_CONDITION_ORDER(HttpStatus.BAD_REQUEST, "Duplicated mock condition cardinal order", "One or more cardinal order value for the mock condition related to the rules [%s] are duplicated."),
+    MOCK_RESOURCE_BAD_REQUEST_INVALID_UNARY_CONDITION(HttpStatus.BAD_REQUEST, "Invalid unary condition", "The unary condition for mock rule [%s] at order [%d] is set with a condition value but it must be set with null value."),
+    MOCK_RESOURCE_BAD_REQUEST_INVALID_BINARY_CONDITION(HttpStatus.BAD_REQUEST, "Invalid binary condition", "The binary condition for mock rule [%] at order [%d] is set without a condition value but it must be set with non-null value."),
+    MOCK_RESOURCE_BAD_REQUEST_INVALID_REGEX(HttpStatus.BAD_REQUEST, "Invalid regex condition", "The regular expression set in the condition for mock rule [%] at order [%d] is invalid and cannot be used as valid value."),
+    MOCK_RESOURCE_BAD_REQUEST_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "Invalid content type in condition", "The content type of mock condition for mock rule [%] at order [%d] is set as [%s] but it is incompatible with [%s] content."),
+    MOCK_RESOURCE_BAD_REQUEST_UNPARSEABLE_RESPONSE_BODY(HttpStatus.BAD_REQUEST, "Invalid format for response body", "The response body related to the mock rule [%] is not passed as a valid Base64 content."),
+    MOCK_RESOURCE_CONFLICT(HttpStatus.CONFLICT, "Mock resource already exists", "Another mock resource exists with id [%s]."),
+    MOCK_RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Mock resource not found", "No valid mock resource found with id [%s]."),
+    MOCK_RULE_NOT_FOUND(HttpStatus.NOT_FOUND, "Mock rule not found", "No valid mock rule with id [%s] was found for mock resource found with id [%s]."),
+    MOCK_RESOURCE_GENERATION_FROM_ARCHETYPE_INVALID_HTTPSTATUS(HttpStatus.BAD_REQUEST, "Invalid HTTP status", "No valid response defined in archetype for the HTTP status [%d]."),
+    MOCK_RESOURCE_GENERATION_FROM_ARCHETYPE_MISSING_URL_PARAMETER(HttpStatus.BAD_REQUEST, "Missing URL parameter", "The request must provide all the path parameters defined by the archetype: %s"),
+    OPENAPI_IMPORT_INVALID_FILE_CONTENT(HttpStatus.BAD_REQUEST, "Invalid OpenAPI file", "The passed OpenAPI file is invalid or malformed and cannot be analyzed."),
+    SCRIPT_NOT_FOUND(HttpStatus.NOT_FOUND, "Script not found", "No valid script found with name [%s]."),
+    ;
 
-  public final HttpStatus httpStatus;
-  public final String title;
-  public final String details;
+    public final HttpStatus httpStatus;
+    public final String title;
+    public final String details;
 
 
-  AppError(HttpStatus httpStatus, String title, String details) {
-    this.httpStatus = httpStatus;
-    this.title = title;
-    this.details = details;
-  }
+    AppError(HttpStatus httpStatus, String title, String details) {
+        this.httpStatus = httpStatus;
+        this.title = title;
+        this.details = details;
+    }
 }
 
 

--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceEntityToMockResource.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockResourceEntityToMockResource.java
@@ -1,9 +1,6 @@
 package it.gov.pagopa.mocker.config.mapper;
 
-import it.gov.pagopa.mocker.config.entity.MockConditionEntity;
-import it.gov.pagopa.mocker.config.entity.MockResourceEntity;
-import it.gov.pagopa.mocker.config.entity.MockResponseEntity;
-import it.gov.pagopa.mocker.config.entity.MockRuleEntity;
+import it.gov.pagopa.mocker.config.entity.*;
 import it.gov.pagopa.mocker.config.model.mockresource.*;
 import org.modelmapper.Converter;
 import org.modelmapper.spi.MappingContext;
@@ -52,6 +49,21 @@ public class ConvertMockResourceEntityToMockResource implements Converter<MockRe
             }
             conditions.sort(Comparator.comparingInt(MockCondition::getOrder));
 
+            ScriptingEntity scriptingEntity = srcRule.getScripting();
+            MockScripting mockScripting = null;
+            if (scriptingEntity != null) {
+                mockScripting = MockScripting.builder()
+                        .scriptName(scriptingEntity.getScriptName())
+                        .isActive(scriptingEntity.getIsActive())
+                        .inputParameters(scriptingEntity.getParameters().stream()
+                                .map(parameter -> ScriptParameter.builder()
+                                        .name(parameter.getName())
+                                        .value(parameter.getValue())
+                                        .build())
+                                .toList())
+                        .build();
+            }
+
             MockRule rule = MockRule.builder()
                     .id(srcRule.getId())
                     .name(srcRule.getName())
@@ -59,6 +71,7 @@ public class ConvertMockResourceEntityToMockResource implements Converter<MockRe
                     .isActive(srcRule.isActive())
                     .tags(new ArrayList<>(srcRule.getTags()))
                     .conditions(conditions)
+                    .scripting(mockScripting)
                     .response(response)
                     .build();
             rules.add(rule);

--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockRuleToMockRuleEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertMockRuleToMockRuleEntity.java
@@ -1,12 +1,10 @@
 package it.gov.pagopa.mocker.config.mapper;
 
-import it.gov.pagopa.mocker.config.entity.MockConditionEntity;
-import it.gov.pagopa.mocker.config.entity.MockResponseEntity;
-import it.gov.pagopa.mocker.config.entity.MockRuleEntity;
-import it.gov.pagopa.mocker.config.entity.ResponseHeaderEntity;
+import it.gov.pagopa.mocker.config.entity.*;
 import it.gov.pagopa.mocker.config.model.mockresource.MockCondition;
 import it.gov.pagopa.mocker.config.model.mockresource.MockResponse;
 import it.gov.pagopa.mocker.config.model.mockresource.MockRule;
+import it.gov.pagopa.mocker.config.model.mockresource.MockScripting;
 import it.gov.pagopa.mocker.config.util.Utility;
 import org.modelmapper.Converter;
 import org.modelmapper.spi.MappingContext;
@@ -30,6 +28,20 @@ public class ConvertMockRuleToMockRuleEntity implements Converter<MockRule, Mock
     }
 
     private MockRuleEntity buildMockRule(MockRule mockRule, MockResponseEntity mockResponseEntity) {
+        MockScripting mockScripting = mockRule.getScripting();
+        ScriptingEntity scriptingEntity = null;
+        if (mockScripting != null) {
+            scriptingEntity = ScriptingEntity.builder()
+                    .scriptName(mockScripting.getScriptName())
+                    .isActive(mockScripting.getIsActive())
+                    .parameters(mockScripting.getInputParameters().stream()
+                            .map(parameter -> NameValueEntity.builder()
+                                    .name(parameter.getName())
+                                    .value(parameter.getValue())
+                                    .build())
+                            .toList())
+                    .build();
+        }
         mockRule.setIdIfNull(Utility.generateUUID());
         return MockRuleEntity.builder()
                 .id(mockRule.getId())
@@ -37,6 +49,7 @@ public class ConvertMockRuleToMockRuleEntity implements Converter<MockRule, Mock
                 .order(mockRule.getOrder())
                 .isActive(mockRule.getIsActive())
                 .response(mockResponseEntity)
+                .scripting(scriptingEntity)
                 .tags(new HashSet<>(mockRule.getTags().stream().map(String::trim).filter(value -> !value.isBlank()).toList()))
                 .build();
     }

--- a/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertScriptEntityToScriptMetadata.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/mapper/ConvertScriptEntityToScriptMetadata.java
@@ -1,0 +1,21 @@
+package it.gov.pagopa.mocker.config.mapper;
+
+import it.gov.pagopa.mocker.config.entity.ScriptEntity;
+import it.gov.pagopa.mocker.config.model.script.ScriptMetadata;
+import org.modelmapper.Converter;
+import org.modelmapper.spi.MappingContext;
+
+public class ConvertScriptEntityToScriptMetadata implements Converter<ScriptEntity, ScriptMetadata> {
+
+    @Override
+    public ScriptMetadata convert(MappingContext<ScriptEntity, ScriptMetadata> mappingContext) {
+        ScriptEntity source = mappingContext.getSource();
+        return ScriptMetadata.builder()
+                .id(source.getId())
+                .name(source.getName())
+                .description(source.getDescription())
+                .inputParameters(source.getInputParameters())
+                .outputParameters(source.getOutputParameters())
+                .build();
+    }
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockRule.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockRule.java
@@ -60,6 +60,10 @@ public class MockRule implements Serializable {
     @Valid
     private List<MockCondition> conditions;
 
+    @JsonProperty("scripting")
+    @Schema(description = "The information about the script to be executed by Mocker if all the conditions occurs.")
+    private MockScripting scripting;
+
     @JsonProperty("response")
     @Schema(description = "The mocked response that the Mocker will give as output if all the condition are verified for the mock rule.")
     @NotNull(message = "The mock response to be assigned the mock rule cannot be null.")

--- a/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockScripting.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/MockScripting.java
@@ -1,0 +1,49 @@
+package it.gov.pagopa.mocker.config.model.mockresource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The model that define the information about the script to be
+ * executed by Mocker if all the conditions occurs.
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "The information about the script to be executed by Mocker if all the conditions occurs.")
+public class MockScripting implements Serializable {
+
+    @JsonProperty("script_name")
+    @Schema(description = "The name of the script that will be executed by the Mocker for the associated rule.", example = "delay")
+    @NotNull(message = "The name of the script that will be executed by the Mocker for the associated rule cannot be null.")
+    private String scriptName;
+
+    @JsonProperty("description")
+    @Schema(description = "The human-readable description that explains the behavior of the script.", example = "Lorem ipsum sit dolorem")
+    private String description;
+
+    @JsonProperty("is_active")
+    @Schema(description = "The flag that define if the scripting process is enabled for the associated rule.", example = "true")
+    @NotNull(message = "The flag that define if the scripting process is enabled for the associated rule cannot be null.")
+    private Boolean isActive;
+
+    @JsonProperty("input_parameters")
+    @Schema(description = "The list of parameters to be set as input for the execution of the script in the Mocker.")
+    @NotNull(message = "The list of parameters to be set as input for the execution cannot be null.")
+    private List<ScriptParameter> inputParameters;
+
+    @JsonProperty("output_parameters")
+    @Schema(description = "The list of parameters that will be returned as output from the script during runtime.", example = "dynamic.res")
+    private List<String> outputParameters;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/ScriptParameter.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/mockresource/ScriptParameter.java
@@ -1,0 +1,36 @@
+package it.gov.pagopa.mocker.config.model.mockresource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+/**
+ * The model that define the parameter to be set as input for the execution of the script in the Mocker
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "The parameter to be set as input for the execution of the script in the Mocker.")
+public class ScriptParameter implements Serializable {
+
+    @JsonProperty("name")
+    @Schema(description = "The name of the parameter to be set as input. In script, it will be retrieved wit the annotation parameters.FIELD_NAME.", example = "some-param")
+    @NotNull(message = "The name of the parameter to be assigned as input for the script cannot be null.")
+    @NotBlank(message = "The name of the parameter to be assigned as input for the script cannot be blank.")
+    private String name;
+
+    @JsonProperty("value")
+    @Schema(description = "The value of the parameter to be set as input. The value can be a constant or a dynamic value, retrievable from request body.", example = "some-value")
+    @NotNull(message = "The value of the parameter to be assigned as input for the script cannot be null.")
+    private String value;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/model/script/ScriptMetadata.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/script/ScriptMetadata.java
@@ -1,0 +1,51 @@
+package it.gov.pagopa.mocker.config.model.script;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The model that define the script that can be executed by Mocker and that permits
+ * to generate dynamic values based on scripted execution.
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "The script that can be executed by Mocker and that permits to generate dynamic values based on scripted execution.")
+public class ScriptMetadata implements Serializable {
+
+    @JsonProperty("id")
+    @Schema(description = "The unique identifier of the script.", example = "fb5363bcf68f687c9caeddbc221769f6")
+    private String id;
+
+    @JsonProperty("name")
+    @Schema(description = "The name of the script.", example = "delay")
+    @NotBlank(message = "The name associated to the script cannot be null or blank.")
+    private String name;
+
+    @JsonProperty("description")
+    @Schema(description = "The human-readable description that explains the behavior of the script.", example = "Lorem ipsum sit dolorem")
+    @NotBlank(message = "The name associated to the script cannot be null or blank.")
+    private String description;
+
+    @JsonProperty("input_parameters")
+    @Schema(description = "The list of parameters to be passed as input to the script during runtime.", example = "name")
+    @NotNull(message = "The list of parameters to be passed as input to the script during runtime cannot be null.")
+    private List<String> inputParameters;
+
+    @JsonProperty("output_parameters")
+    @Schema(description = "The list of parameters that will be returned as output from the script during runtime.", example = "dynamic.res")
+    @NotNull(message = "The list of parameters that will be returned as output from the script during runtime cannot be null.")
+    private List<String> outputParameters;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/model/script/ScriptMetadataList.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/model/script/ScriptMetadataList.java
@@ -1,0 +1,30 @@
+package it.gov.pagopa.mocker.config.model.script;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The model that contains the complete list of scripts to be used for dynamic mock behavior.
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "The complete list of scripts to be used for dynamic mock behavior.")
+public class ScriptMetadataList implements Serializable {
+
+    @JsonProperty("scripts")
+    @NotNull
+    @Schema(description = "The list of retrieved scripts.")
+    private List<ScriptMetadata> scripts;
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/repository/ScriptRepository.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/repository/ScriptRepository.java
@@ -1,0 +1,14 @@
+package it.gov.pagopa.mocker.config.repository;
+
+import it.gov.pagopa.mocker.config.entity.ScriptEntity;
+import it.gov.pagopa.mocker.config.repository.specification.ScriptCriteriaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ScriptRepository extends MongoRepository<ScriptEntity, String>, ScriptCriteriaRepository {
+
+    Optional<ScriptEntity> findByName(String name);
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/repository/specification/ScriptCriteriaRepository.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/repository/specification/ScriptCriteriaRepository.java
@@ -1,0 +1,10 @@
+package it.gov.pagopa.mocker.config.repository.specification;
+
+import it.gov.pagopa.mocker.config.entity.ScriptEntity;
+
+import java.util.List;
+
+public interface ScriptCriteriaRepository {
+
+    List<ScriptEntity> findAll(String name);
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/repository/specification/ScriptCriteriaRepositoryImpl.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/repository/specification/ScriptCriteriaRepositoryImpl.java
@@ -1,0 +1,30 @@
+package it.gov.pagopa.mocker.config.repository.specification;
+
+import it.gov.pagopa.mocker.config.entity.ScriptEntity;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.List;
+
+public class ScriptCriteriaRepositoryImpl implements ScriptCriteriaRepository {
+
+
+    private final MongoTemplate mongoTemplate;
+
+    public ScriptCriteriaRepositoryImpl(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public List<ScriptEntity> findAll(String name) {
+        Query query = new Query().with(Sort.by(Sort.Direction.ASC, "name"));
+        if (StringUtils.isNotEmpty(name)) {
+            query.addCriteria(Criteria.where("name").regex(".*" + name + ".*", "i"));
+        }
+        query.addCriteria(Criteria.where("selectable").is(Boolean.TRUE));
+        return mongoTemplate.find(query, ScriptEntity.class);
+    }
+}

--- a/src/main/java/it/gov/pagopa/mocker/config/service/ScriptingService.java
+++ b/src/main/java/it/gov/pagopa/mocker/config/service/ScriptingService.java
@@ -1,0 +1,42 @@
+package it.gov.pagopa.mocker.config.service;
+
+import it.gov.pagopa.mocker.config.entity.ScriptEntity;
+import it.gov.pagopa.mocker.config.exception.AppError;
+import it.gov.pagopa.mocker.config.exception.AppException;
+import it.gov.pagopa.mocker.config.model.script.ScriptMetadata;
+import it.gov.pagopa.mocker.config.model.script.ScriptMetadataList;
+import it.gov.pagopa.mocker.config.repository.ScriptRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class ScriptingService {
+
+    @Autowired
+    private ScriptRepository scriptRepository;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    public ScriptMetadataList getScripts(String name) {
+        List<ScriptMetadata> scripts;
+        try {
+            List<ScriptEntity> scriptEntities = scriptRepository.findAll(name);
+            scripts = scriptEntities.stream()
+                    .map(script -> modelMapper.map(script, ScriptMetadata.class))
+                    .toList();
+        } catch (DataAccessException e) {
+            log.error("An error occurred while trying to retrieve the list of scripts. ", e);
+            throw new AppException(AppError.INTERNAL_SERVER_ERROR);
+        }
+        return ScriptMetadataList.builder()
+                .scripts(scripts)
+                .build();
+    }
+}


### PR DESCRIPTION
This PR permits to handle the configuration of business logic execution using dedicated scripts.  
The main information about the logic is defined in [this PR](https://github.com/pagopa/pagopa-mocker/pull/21), this one is related only to the configuration APIs that includes the new information in the existing interfaces.

#### List of Changes
 - Updated interface and persistence logic, including references to scripting binding
 - Added dedicated entity that maps the collection used for store script code to be executed by engine
 - Added information on `MockRuleEntity` that permits to refers to script code to be executed in runtime
 - Added new API for retrieve all script metadata that can be assigned to mock rule

#### Motivation and Context
This modification broadens the use cases in which Mocker can be used, adding dynamic logic that can simplify and add expressiveness to tests.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.